### PR TITLE
🧹 Cleaning up some of the syntax from the export

### DIFF
--- a/content/data-misfit.md
+++ b/content/data-misfit.md
@@ -2,18 +2,10 @@
 title: Data Misfit
 description: ''
 date: '2021-07-27T18:43:48.580Z'
-name: data-misfit
 venue: Linear Tikhonov Inversion
-oxa: oxa:VNMrkxzChhdveZyf6lmb/5FnO5etrobjFzok1lt66
-tags: []
-keywords: []
 ---
 
-+++ {"oxa":"oxa:VNMrkxzChhdveZyf6lmb/SdzMpnQ1uoxrZTZEigRT.3","tags":[]}
-
 The observations $d^{obs}$ encode our knowledge about the model obtained from the survey. Any candidate solution $m$ must produce simulated (or predicted) data $d$ that “fit” the observations. Central to this goal is the choice of a “criterion” for measuring misfit between observed and predicted data, and a “tolerance” for deciding what value constitutes an acceptable fit. This is a subject on which an enormous amount of literature has been written but a good reference, written for the inverse problem, is {cite:t}`parker_geophysical_1994`. When errors are Gaussian with zero mean and known standard deviation, then the $L_2$ -norm, is an appropriate choice. We define the misfit to be
-
-+++ {"oxa":"oxa:VNMrkxzChhdveZyf6lmb/VmC2Gwt9nh8NBzEzFntw.10","tags":[]}
 
 ```{math}
 :label: 9424a329
@@ -21,11 +13,7 @@ The observations $d^{obs}$ encode our knowledge about the model obtained from th
 \phi_d=\sum^N_{j=1}\left(\frac{d_j-d_j^{obs}}{\epsilon_j}\right)^2
 ```
 
-+++ {"oxa":"oxa:VNMrkxzChhdveZyf6lmb/LGtxkaP0eCmOSwv2yCxA.2","tags":[]}
-
 where $d_j^{obs}$ is the observation, $\epsilon_j$ is its estimated standard deviation, and $d_j$ is the predicted datum. The quantity
-
-+++ {"oxa":"oxa:VNMrkxzChhdveZyf6lmb/VH8Ys3xxPUcRVsi5Amx2.5","tags":[]}
 
 ```{math}
 :label: c93bd419
@@ -33,11 +21,7 @@ where $d_j^{obs}$ is the observation, $\epsilon_j$ is its estimated standard dev
 \eta_j = \frac {d_j - d_j^{obs}} {\epsilon_j}
 ```
 
-+++ {"oxa":"oxa:VNMrkxzChhdveZyf6lmb/kpKzyTzMXr6blk8gzjGB.3","tags":[]}
-
 is a random variable with zero mean and unit standard deviation and $\phi_d$ , which is the sum of squares of these variables, is the well known $\chi^2$ statistical variable. It has an expected value ({eq}`198b31c2`) and variance ({eq}`000e5f6c`).
-
-+++ {"oxa":"oxa:VNMrkxzChhdveZyf6lmb/M2mlavTuOdq562b8HSOu.4","tags":[]}
 
 ```{math}
 :label: 198b31c2
@@ -45,19 +29,13 @@ is a random variable with zero mean and unit standard deviation and $\phi_d$ , w
 E[\chi^2] = N
 ```
 
-+++ {"oxa":"oxa:VNMrkxzChhdveZyf6lmb/GuroZmXCH97lki21grMx.4","tags":[]}
-
 ```{math}
 :label: 000e5f6c
 
 Var[\chi^2] = 2N
 ```
 
-+++ {"oxa":"oxa:VNMrkxzChhdveZyf6lmb/Nze35pzQKwuIvkMsybde.1","tags":[]}
-
 Thus if we are attempting to find a model $m$ that acceptably fits the data, then models with $\phi_d \simeq N$ are good candidates. For many problems we often denote a target misfit $\phi_d^*$ to be
-
-+++ {"oxa":"oxa:VNMrkxzChhdveZyf6lmb/RtNyPiGmFG19bFMvyya5.4","tags":[]}
 
 ```{math}
 :label: 8e0a1ed0
@@ -65,22 +43,14 @@ Thus if we are attempting to find a model $m$ that acceptably fits the data, the
 \phi_d^*=N
 ```
 
-+++ {"oxa":"oxa:VNMrkxzChhdveZyf6lmb/QYBf9aDSXddRAiHMETkj.3","tags":[]}
-
 but this must only be regarded as a reasonable estimate and some flexibility should be entertained.
 
-+++ {"oxa":"oxa:VNMrkxzChhdveZyf6lmb/zSJwNYpbH41A5f11eCRr.2","tags":[]}
-
 In times past, it was felt that getting an acceptable fit to the data was a sufficient criterion for having a successful inversion. The observed data $\mathbf{d}_{obs}$ are inverted to produce a model $\mathbf{m}$, which is used to forward model the predicted data $\mathbf{d}$. The observed and predicted data are then compared using the data misfit measure. If $\phi_d<\phi_d^*$ the model $\mathbf{m}$ is accepted, but if not, the inversion parameters are adjusted and the process is repeated until an acceptable model is reached. The workflow procedure is delineated below.
-
-+++ {"oxa":"oxa:VNMrkxzChhdveZyf6lmb/6EB3FEfgScnvf73UHMPg.2","tags":[]}
 
 ```{figure} images/VNMrkxzChhdveZyf6lmb-6EB3FEfgScnvf73UHMPg-v2.png
 :name: 6EB3FEfgScnvf73UHMPg
 :align: center
 :width: 70%
 ```
-
-+++ {"oxa":"oxa:VNMrkxzChhdveZyf6lmb/qS0CDhbAOYfAf7rGwRCn.2","tags":[]}
 
 Finding a model that fits the data is a necessary component of an inversion algorithm, but as shown in the next section, it is not sufficient.

--- a/content/equation-index.md
+++ b/content/equation-index.md
@@ -2,14 +2,8 @@
 title: Equation Index
 description: ''
 date: '2021-04-20T22:06:12.601Z'
-name: equation-index
 venue: Equation Index
-oxa: oxa:VNMrkxzChhdveZyf6lmb/BvQrUTEeY6flMS1xdn10
-tags: []
-keywords: []
 ---
-
-+++ {"oxa":"oxa:VNMrkxzChhdveZyf6lmb/1oG2RfNTKhSPAmCGyNA2.13","tags":[]}
 
 ```{math}
 :label: f4385f45
@@ -17,15 +11,11 @@ keywords: []
 s=\frac{1}{v}
 ```
 
-+++ {"oxa":"oxa:VNMrkxzChhdveZyf6lmb/mSbPSXOGQw2RminBZjJI.7","tags":[]}
-
 ```{math}
 :label: 0e35ead3
 
 \rho = 1/\sigma
 ```
-
-+++ {"oxa":"oxa:VNMrkxzChhdveZyf6lmb/5PN8xXuDlR25iGXFKu2l.7","tags":[]}
 
 ```{math}
 :label: 3f2ba4e6
@@ -33,15 +23,11 @@ s=\frac{1}{v}
 \mu = \mu_0 (1 + \kappa)
 ```
 
-+++ {"oxa":"oxa:VNMrkxzChhdveZyf6lmb/Iv43QHUhUicMsAvpWgAb.8","tags":[]}
-
 ```{math}
 :label: 77e80a1d
 
 \mathcal{F}[m] = d
 ```
-
-+++ {"oxa":"oxa:VNMrkxzChhdveZyf6lmb/58SCTuc4u4OkpuZPuoUB.5","tags":[]}
 
 ```{math}
 :label: 3ffde9a8
@@ -49,15 +35,11 @@ s=\frac{1}{v}
 d_j=\mathcal{F}_j[m]
 ```
 
-+++ {"oxa":"oxa:VNMrkxzChhdveZyf6lmb/2612PkADvNiBlkg5RysF.7","tags":[]}
-
 ```{math}
 :label: ec8a3fad
 
 \mathcal{F}[\alpha f+\beta g]=\alpha\mathcal{F}[f]+\beta\mathcal{F}[g]
 ```
-
-+++ {"oxa":"oxa:VNMrkxzChhdveZyf6lmb/kcG1fkQEwzcMhorgrH32.12","tags":[]}
 
 ```{math}
 :label: f40ae85f
@@ -65,15 +47,11 @@ d_j=\mathcal{F}_j[m]
 d_j=\int^b_ag_j(x)m(x)dx
 ```
 
-+++ {"oxa":"oxa:VNMrkxzChhdveZyf6lmb/bzvw8czOV3HO6mqz7Oet.6","tags":[]}
-
 ```{math}
 :label: c61a0203
 
 y = m \otimes w
 ```
-
-+++ {"oxa":"oxa:VNMrkxzChhdveZyf6lmb/lO4LLkjjq7kbDfS6TCXp.7","tags":[]}
 
 ```{math}
 :label: a7524253
@@ -81,15 +59,11 @@ y = m \otimes w
 y(t_j)=\int^{\infty}_{-\infty}m(\tau)w(t_j-\tau)d\tau
 ```
 
-+++ {"oxa":"oxa:VNMrkxzChhdveZyf6lmb/5ifQPlmRIekmKf3BDcM0.9","tags":[]}
-
 ```{math}
 :label: 32fe3486
 
 \vec{B}(\vec{r}_j)=\frac{\mu_0}{4\pi}\int\frac{\vec{J}(\vec{r}\prime)\times\hat{r}}{\left|\vec{r}_j-\vec{r}\prime\right|^2}
 ```
-
-+++ {"oxa":"oxa:VNMrkxzChhdveZyf6lmb/XsjJaecfwHID0KAINBLu.9","tags":[]}
 
 ```{math}
 :label: 9e1acfa8
@@ -97,15 +71,11 @@ y(t_j)=\int^{\infty}_{-\infty}m(\tau)w(t_j-\tau)d\tau
 d_j^{(1)}=\int^b_a g_j(x)m_1(x)dx
 ```
 
-+++ {"oxa":"oxa:VNMrkxzChhdveZyf6lmb/T266ULKhnxY9ij5tql83.7","tags":[]}
-
 ```{math}
 :label: 89373b07
 
 d_j^{(2)}=\int^b_a g_j(x)m_2(x)dx
 ```
-
-+++ {"oxa":"oxa:VNMrkxzChhdveZyf6lmb/LyvrSwMQ8phodV2Zk4sm.8","tags":[]}
 
 ```{math}
 :label: fc8ce57f
@@ -113,15 +83,11 @@ d_j^{(2)}=\int^b_a g_j(x)m_2(x)dx
 \begin{aligned}d_j=\int^b_a g_j(x)[\alpha & m_1(x) +\beta m_2(x)]\\ d_j=\alpha &d_j^{(1)}+\beta d_j^{(2)}\end{aligned}
 ```
 
-+++ {"oxa":"oxa:VNMrkxzChhdveZyf6lmb/DdipWkTJ9eCP4tao8oW9.8","tags":[]}
-
 ```{math}
 :label: 7f61dce7
 
 d_j=\int^b_ag_j(x)m^2(x)dx
 ```
-
-+++ {"oxa":"oxa:VNMrkxzChhdveZyf6lmb/FCouZX8qA3eeWl1zi0Zr.7","tags":[]}
 
 ```{math}
 :label: 0c8e0714
@@ -129,15 +95,11 @@ d_j=\int^b_ag_j(x)m^2(x)dx
 \nabla\cdot\sigma\nabla V=-I\delta(\vec{r}-\vec{r}\prime)
 ```
 
-+++ {"oxa":"oxa:VNMrkxzChhdveZyf6lmb/7vm3mQYoOAkNVRhsglMU.13","tags":[]}
-
 ```{math}
 :label: a19b615c
 
 V^2_{rms}(t_j)=\frac{1}{t_j}\int^{t_{max}}_0 v^2_{int}(u)H(t_j-u)du
 ```
-
-+++ {"oxa":"oxa:VNMrkxzChhdveZyf6lmb/TS1EFEmJCuYjiRf9oce2.9","tags":[]}
 
 ```{math}
 :label: cc63b0e8
@@ -145,15 +107,11 @@ V^2_{rms}(t_j)=\frac{1}{t_j}\int^{t_{max}}_0 v^2_{int}(u)H(t_j-u)du
 V^2_{rms}(t)=\frac{1}{t}\int^{t_{max}}_0 v_{int}^2(u)H(t-u)du
 ```
 
-+++ {"oxa":"oxa:VNMrkxzChhdveZyf6lmb/YN3xWuUFLvRxO1PyurOF.9","tags":[]}
-
 ```{math}
 :label: 815dcec5
 
 v_{int}=V_{rms}(t)\left(1+\frac{2tV'_{rms}(t)}{V_{rms}(t)}\right)^{\frac{1}{2}}
 ```
-
-+++ {"oxa":"oxa:VNMrkxzChhdveZyf6lmb/BoYqRK5BjSO6jwAAB4AW.10","tags":[]}
 
 ```{math}
 :label: c2de4591
@@ -161,15 +119,11 @@ v_{int}=V_{rms}(t)\left(1+\frac{2tV'_{rms}(t)}{V_{rms}(t)}\right)^{\frac{1}{2}}
 V_{rms}(t)=v_0+a\sin(2\pi ft)
 ```
 
-+++ {"oxa":"oxa:VNMrkxzChhdveZyf6lmb/dB1iZKL3R6gRTlI9mOVG.9","tags":[]}
-
 ```{math}
 :label: 2f6367b7
 
 V'_{rms}(t)=2\pi af\cos(2\pi ft)
 ```
-
-+++ {"oxa":"oxa:VNMrkxzChhdveZyf6lmb/eWJc8RI8UDu2T19kMQSt.6","tags":[]}
 
 ```{math}
 :label: 1bc2c17d
@@ -177,15 +131,11 @@ V'_{rms}(t)=2\pi af\cos(2\pi ft)
 d^{obs}=d^{true}+\delta d
 ```
 
-+++ {"oxa":"oxa:VNMrkxzChhdveZyf6lmb/TaXITd9sMowbH20A8EKE.6","tags":[]}
-
 ```{math}
 :label: d73ceb50
 
 \mathcal{F}^{-1}[d^{true}]=m_c
 ```
-
-+++ {"oxa":"oxa:VNMrkxzChhdveZyf6lmb/yJTiTKTETafVxEIFbai8.8","tags":[]}
 
 ```{math}
 :label: 5c78d503
@@ -193,15 +143,11 @@ d^{obs}=d^{true}+\delta d
 \mathcal{F}^{-1}[d^{obs}]=\mathcal{F}^{-1}[d^{true}+\delta d]=m_c+\delta m
 ```
 
-+++ {"oxa":"oxa:VNMrkxzChhdveZyf6lmb/LvqtQqFT2lBARuGaF4jb.5","tags":[]}
-
 ```{math}
 :label: ec61be48
 
 \delta v_{int}\propto \sqrt{\frac{fta}{v_0}}
 ```
-
-+++ {"oxa":"oxa:VNMrkxzChhdveZyf6lmb/R13nNIFBXYUFWWW3iuEr.7","tags":[]}
 
 ```{math}
 :label: d44e43b7
@@ -209,15 +155,11 @@ d^{obs}=d^{true}+\delta d
 P(m|d^{obs})\propto P(d^{obs}|m)P(m)
 ```
 
-+++ {"oxa":"oxa:VNMrkxzChhdveZyf6lmb/df5PAaspJSNpPmBJ7nwu.7","tags":[]}
-
 ```{math}
 :label: 7633cf80
 
 \begin{aligned}&\text{Minimize}~~\phi=\phi_d+\beta\phi_m\\ &\text{subject to}~~m_l<m<m_u,\end{aligned}
 ```
-
-+++ {"oxa":"oxa:VNMrkxzChhdveZyf6lmb/xQEIP2FNnxfk6ELkP28o.8","tags":[]}
 
 ```{math}
 :label: 4f6a44b9
@@ -225,15 +167,11 @@ P(m|d^{obs})\propto P(d^{obs}|m)P(m)
 g_j(x)= e^{p_jx}\cos(2\pi q_jx)
 ```
 
-+++ {"oxa":"oxa:VNMrkxzChhdveZyf6lmb/Gm7gHsFXic5G1yoZSCkn.10","tags":[]}
-
 ```{math}
 :label: be6adec9
 
 \begin{aligned} d_j&=\int_0^{x_1}g_j(x)m_1dx +\int_{x_1}^{x_2}g_j(x)m_2dx+\dots \\ &=\sum^M_{i=1}\left(\int_{x_{k-1}}^{x_k}g_j\left(x\right)dx\right)m_i\\ &\\ d_j &= \mathbf g_j \mathbf m\end{aligned}
 ```
-
-+++ {"oxa":"oxa:VNMrkxzChhdveZyf6lmb/UY5AXhKxS1h3WyGYrl2H.13","tags":[]}
 
 ```{math}
 :label: d031bcf8
@@ -241,15 +179,11 @@ g_j(x)= e^{p_jx}\cos(2\pi q_jx)
 \begin{aligned} \mathbf{d} = \mathbf{G}\mathbf{m} = \begin{bmatrix} d_1\\ \vdots\\ d_{N} \end{bmatrix}\end{aligned}
 ```
 
-+++ {"oxa":"oxa:VNMrkxzChhdveZyf6lmb/2phjcwor9mrVgYufGT39.7","tags":[]}
-
 ```{math}
 :label: 2664f2ef
 
 G_{jk} = \int_{x_{k-1}}^{x_k} g_j(x) dx
 ```
-
-+++ {"oxa":"oxa:VNMrkxzChhdveZyf6lmb/GtIrygcvqO2irqYxf3Ek.8","tags":[]}
 
 ```{math}
 :label: adc69a91
@@ -257,15 +191,11 @@ G_{jk} = \int_{x_{k-1}}^{x_k} g_j(x) dx
 \mathbf{d}^{obs}=\mathbf{d}+\mathbf{n}
 ```
 
-+++ {"oxa":"oxa:VNMrkxzChhdveZyf6lmb/BGPdowi0KZw5sVvtq3iu.9","tags":[]}
-
 ```{math}
 :label: 9e813186
 
 \epsilon_j = \%|d_j| + \nu_j
 ```
-
-+++ {"oxa":"oxa:VNMrkxzChhdveZyf6lmb/VmC2Gwt9nh8NBzEzFntw.10","tags":[]}
 
 ```{math}
 :label: 9424a329
@@ -273,15 +203,11 @@ G_{jk} = \int_{x_{k-1}}^{x_k} g_j(x) dx
 \phi_d=\sum^N_{j=1}\left(\frac{d_j-d_j^{obs}}{\epsilon_j}\right)^2
 ```
 
-+++ {"oxa":"oxa:VNMrkxzChhdveZyf6lmb/VH8Ys3xxPUcRVsi5Amx2.5","tags":[]}
-
 ```{math}
 :label: c93bd419
 
 \eta_j = \frac {d_j - d_j^{obs}} {\epsilon_j}
 ```
-
-+++ {"oxa":"oxa:VNMrkxzChhdveZyf6lmb/M2mlavTuOdq562b8HSOu.4","tags":[]}
 
 ```{math}
 :label: 198b31c2
@@ -289,15 +215,11 @@ G_{jk} = \int_{x_{k-1}}^{x_k} g_j(x) dx
 E[\chi^2] = N
 ```
 
-+++ {"oxa":"oxa:VNMrkxzChhdveZyf6lmb/GuroZmXCH97lki21grMx.4","tags":[]}
-
 ```{math}
 :label: 000e5f6c
 
 Var[\chi^2] = 2N
 ```
-
-+++ {"oxa":"oxa:VNMrkxzChhdveZyf6lmb/RtNyPiGmFG19bFMvyya5.4","tags":[]}
 
 ```{math}
 :label: 8e0a1ed0
@@ -305,15 +227,11 @@ Var[\chi^2] = 2N
 \phi_d^*=N
 ```
 
-+++ {"oxa":"oxa:VNMrkxzChhdveZyf6lmb/hptZlzW1HfA6qBTD3N54.4","tags":[]}
-
 ```{math}
 :label: 5bb81c63
 
 \phi_m=\int (m-m^{ref})^2 dx
 ```
-
-+++ {"oxa":"oxa:VNMrkxzChhdveZyf6lmb/V0RZ0YR4ZH7hHSIFgXMR.4","tags":[]}
 
 ```{math}
 :label: dd987b9d
@@ -321,15 +239,11 @@ Var[\chi^2] = 2N
 \phi_m=\int \left(\frac{d(m-m^{ref})}{dx}\right)^2 dx
 ```
 
-+++ {"oxa":"oxa:VNMrkxzChhdveZyf6lmb/MWve8oSE6siZ6gn9obmF.6","tags":[]}
-
 ```{math}
 :label: 05257042
 
 \phi_m=\alpha_s\int (m-m^{ref})^2 dx+\alpha_x\int (\frac{d(m-m^{ref})}{dx})^2 dx
 ```
-
-+++ {"oxa":"oxa:VNMrkxzChhdveZyf6lmb/ZemZcVOzmmmfCXWHLIiW.4","tags":[]}
 
 ```{math}
 :label: 64af53ab
@@ -337,15 +251,11 @@ Var[\chi^2] = 2N
 \phi_m=\|\mathbf{m - m^{ref}}\|^2=\sum_{i=1}^M(m_i-m^{ref}_i)^2
 ```
 
-+++ {"oxa":"oxa:VNMrkxzChhdveZyf6lmb/yETuK7zWoVYTBA0gnIC7.4","tags":[]}
-
 ```{math}
 :label: 8242954b
 
 \phi_m=\|\frac{d\mathbf{m}}{dx}\|^2=\sum_{i=1}^{M-1}(m_{i+1}-m_i)^2
 ```
-
-+++ {"oxa":"oxa:VNMrkxzChhdveZyf6lmb/QvyNTADmViOIBRurAW2M.6","tags":[]}
 
 ```{math}
 :label: fd471526
@@ -353,19 +263,13 @@ Var[\chi^2] = 2N
 \phi(m) = \phi_d(m)+\beta\phi_m(m)
 ```
 
-+++ {"oxa":"oxa:VNMrkxzChhdveZyf6lmb/bZ96k0YcsCv0EP1eoqhM.4","tags":[]}
-
 ```{math}
 :label: 7c304ef3
 
 \phi=T+\beta F
 ```
 
-+++ {"oxa":"oxa:VNMrkxzChhdveZyf6lmb/nMhKCJMtSvLz5oZvnlMe.6","tags":[]}
-
 $$\mathbf{g}_j(\mathbf{x}) = e^{p_j\mathbf{x}} cos (2 \pi q_j \mathbf{x}) \Delta x$$
-
-+++ {"oxa":"oxa:VNMrkxzChhdveZyf6lmb/V9tgF8Wdjl6sEEWWPM2C.5","tags":[]}
 
 ```{math}
 :label: 8839db7e

--- a/content/exercise-ill-conditioning-non-uniqueness.md
+++ b/content/exercise-ill-conditioning-non-uniqueness.md
@@ -2,16 +2,10 @@
 title: 'Exercise 1: Nonuniqueness and Ill-conditioning '
 description: ''
 date: '2021-07-27T21:10:24.329Z'
-name: exercise-ill-conditioning-non-uniqueness
 venue: Inverse Theory
-oxa: oxa:VNMrkxzChhdveZyf6lmb/GGlM0PGWLPr83CAg9qM7
-tags: []
-keywords: []
 ---
 
-+++ {"oxa":"oxa:VNMrkxzChhdveZyf6lmb/Sd1fQKcbgQiVQ12ldX6Z.7","tags":[]}
-
-In this investigation you can explore the ideas of nonuniqueness and ill-conditioning as applied in the forward and inverse mappings using the rms to interval velocity shown above. The images throughout the previous examples are reproduced in the Jupyter notebook RMStoIntervalVelocity_Notebook. The corresponding notebook [RMStoIntervalVelocity_App.ipynb](oxa:VNMrkxzChhdveZyf6lmb/mdpRd2BmRVWZ830Wf1cp 'RMStoIntervalVelocity_App.ipynb') contains interactive widgets that allow you to adjust parameters and view the results for the following:
+In this investigation you can explore the ideas of nonuniqueness and ill-conditioning as applied in the forward and inverse mappings using the rms to interval velocity shown above. The images throughout the previous examples are reproduced in the Jupyter notebook RMStoIntervalVelocity_Notebook. The corresponding notebook [RMStoIntervalVelocity_App.ipynb](./rms-to-interval-velocity.ipynb) contains interactive widgets that allow you to adjust parameters and view the results for the following:
 
 - **Forward modelling** - calculated rms velocity data $V_{rms}$ given an adjustable interval velocity model $v_{int}$
 - **Invert ‘infinite’ accurate data** - given the adjustable $V_{rms}$ data, recover the $v_{int}$ model from inversion and compare with the true model
@@ -26,7 +20,5 @@ In this investigation you can explore the ideas of nonuniqueness and ill-conditi
     - _Do small changes in the data produce small changes in the model?_
   - _With noise added, does your choice of the optimal interpolation method change?_
   - _How many different data sets and models you could create from the adjustable parameters?_
-
-+++ {"oxa":"oxa:VNMrkxzChhdveZyf6lmb/ktobej3ViGF4zIsgYfEy.1","tags":[]}
 
 The Jupyter notebooks associated with this investigation can be downloaded and run locally or run through the Binder link at the top of the notebooks. More details on this can be found in [Getting Started - Jupyter Notebook Apps](oxa:VNMrkxzChhdveZyf6lmb/txiA7lIdCWcNNYh4xduj 'Getting Started - Jupyter Notebook Apps').

--- a/content/exercise-linear-tikhonov-inversion.md
+++ b/content/exercise-linear-tikhonov-inversion.md
@@ -2,18 +2,10 @@
 title: 'Exercise 2: Linear Tikhonov Inversion'
 description: ''
 date: '2021-07-27T21:40:39.390Z'
-name: exercise-linear-tikhonov-inversion
 venue: Linear Tikhonov Inversion
-oxa: oxa:VNMrkxzChhdveZyf6lmb/RqZEtlNRUGIEmADmEFHd
-tags: []
-keywords: []
 ---
 
-+++ {"oxa":"oxa:VNMrkxzChhdveZyf6lmb/cn7xYi7rFN83vZPOqXsr.12","tags":[]}
-
 In this investigation you can explore the components of a 1D synthetic inversion example, starting with model building, defining the kernel function, then forward modelling the data, adding noise, and finally inverting the data to recover a model. Specific instances of these components have been shown throughout the text above, and can be reproduced in the Jupyter notebook [LinearTikhonovInversion_Notebook.ipynb](oxa:VNMrkxzChhdveZyf6lmb/lb7CgEnVPzfs79VcKpB1 'LinearTikhonovInversion_Notebook.ipynb'). The corresponding notebook [LinearTikhonovInversion_App.ipynb](oxa:VNMrkxzChhdveZyf6lmb/8gDAkt6Yn0QN26MssI0p 'LinearTikhonovInversion_App.ipynb') contains the interactive widgets that allow you to adjust parameters and view results for the following.
-
-+++ {"oxa":"oxa:VNMrkxzChhdveZyf6lmb/pcJkkRWWTJ57WlbonrJZ.1","tags":[]}
 
 ## Forward Problem
 
@@ -34,8 +26,6 @@ The concepts about forward modelling can be explored individually in Steps 1-3, 
 - **Step 3 - Simulate data and add noise**
   - _Consider different noise levels_
     - _When is the data dominated by the noise rather than signal from the model?_
-
-+++ {"oxa":"oxa:VNMrkxzChhdveZyf6lmb/5brthjYabJBhlwizwJRB.1","tags":[]}
 
 ## Inverse Problem
 
@@ -81,7 +71,5 @@ The numerical details regarding how we obtain a solution to the inverse problem 
   - Recall the target data misfit value is $\phi_d^*=\chi_{fact}N$, thus when $\chi_{fact}=1$ the expected value of the misfit is the number of data $N$ ({eq}`198b31c2`)
   - _How does the model change when the inversion overfits the data_ $(\chi_{fact}<<1)$?
   - _How does the model change when the inversion underfits the data_ $(\chi_{fact}>>1)$?
-
-+++ {"oxa":"oxa:VNMrkxzChhdveZyf6lmb/ktobej3ViGF4zIsgYfEy.1","tags":[]}
 
 The Jupyter notebooks associated with this investigation can be downloaded and run locally or run through the Binder link at the top of the notebooks. More details on this can be found in [Getting Started - Jupyter Notebook Apps](oxa:VNMrkxzChhdveZyf6lmb/txiA7lIdCWcNNYh4xduj 'Getting Started - Jupyter Notebook Apps').

--- a/content/forward-mapping.md
+++ b/content/forward-mapping.md
@@ -2,232 +2,142 @@
 title: Forward Mapping
 description: ''
 date: '2021-07-26T21:58:19.425Z'
-name: forward-mapping
 venue: Inverse Theory
-oxa: oxa:VNMrkxzChhdveZyf6lmb/0VkRIdgDMntmQzhLzHiP
-tags: []
-keywords: []
 ---
-
-+++ {"oxa":"oxa:VNMrkxzChhdveZyf6lmb/X7PezrLoTdQEBWzoWsBb.2","tags":[]}
 
 Simulating data requires being able to solve
 
-+++ {"oxa":"oxa:VNMrkxzChhdveZyf6lmb/Iv43QHUhUicMsAvpWgAb.8","tags":[]}
+$$ \mathcal{F}[m] = d $$
 
-```{math}
-:label: 77e80a1d
-
-\mathcal{F}[m] = d
-```
-
-+++ {"oxa":"oxa:VNMrkxzChhdveZyf6lmb/AXgh2yqCwkiDu5HjZat0.3","tags":[]}
-
-where $m$ is an element of the model space $\mathcal{M}$, and $\mathcal{F}$ is the forward mapping. $\mathcal{F}$ encompasses the physics of the problem, the geometry of the survey and details about Tx and Rx. The operation generates a simulated data set which is an element of data space $\mathcal{D}$. The procedure is conceptualized in the diagram below ({numref}`Figure %s <3zKlKqaAqrRWcQMMX7H6>`).
-
-+++ {"oxa":"oxa:VNMrkxzChhdveZyf6lmb/3zKlKqaAqrRWcQMMX7H6.2","tags":[]}
+where $m$ is an element of the model space $\mathcal{M}$, and $\mathcal{F}$ is the forward mapping. $\mathcal{F}$ encompasses the physics of the problem, the geometry of the survey and details about Tx and Rx. The operation generates a simulated data set which is an element of data space $\mathcal{D}$. The procedure is conceptualized in the diagram below (@fig:forward-mapping).
 
 ```{figure} images/VNMrkxzChhdveZyf6lmb-3zKlKqaAqrRWcQMMX7H6-v2.png
-:name: 3zKlKqaAqrRWcQMMX7H6
+:name: fig:forward-mapping
 :align: center
 :width: 60%
+Mapping between model space and data space
 ```
 
-+++ {"oxa":"oxa:VNMrkxzChhdveZyf6lmb/CpLB2bNalogSqtyD138N.4","tags":[]}
-
-### 1.4.1. Model space
+### Model space
 
 Model space is a vector space with key components. Its elements can be functions or Euclidean vectors. Model space comes equipped with two important attributes:
 
-- **Rules for inner products** - This allows the concept of angles between elements to be computed. This allows us to determine whether elements are parallel or perpendicular to each other.
-- **Norms to measure length** - In our optimization solution it will be important to measure the “length” of the vectors so that we can distinguish between small and large elements.
+Rules for inner products
+: This allows the concept of angles between elements to be computed. This allows us to determine whether elements are parallel or perpendicular to each other.
 
-See {cite:p}`parker_geophysical_1994` for a more in depth discussion.
+Norms to measure length
+: In our optimization solution it will be important to measure the “length” of the vectors so that we can distinguish between small and large elements.
 
-For our seismic refraction problem our model space elements can be functions $v(z)$ or $M$-length vector of velocity values: $\mathbf{v}=(v_1, \dots,v_M)$. These are shown in {numref}`Figure %s <1MMgRl6oRm8JDCBnlEsk>`.
+See @parker_geophysical_1994 for a more in depth discussion.
 
-+++ {"oxa":"oxa:VNMrkxzChhdveZyf6lmb/1MMgRl6oRm8JDCBnlEsk.3","tags":[]}
+For our seismic refraction problem (@seismic-refraction-experiment) our model space elements can be functions $v(z)$ or an $M$-length vector of velocity values: $\mathbf{v}=(v_1, \dots,v_M)$. These are shown in @fig:seismic-velocity-values.
 
 ```{figure} images/VNMrkxzChhdveZyf6lmb-1MMgRl6oRm8JDCBnlEsk-v3.png
-:name: 1MMgRl6oRm8JDCBnlEsk
+:name: fig:seismic-velocity-values
 :align: center
 :width: 30%
+
+Model space elements can be functions $v(z)$ or $M$-length vector of velocity values.
 ```
 
-+++ {"oxa":"oxa:VNMrkxzChhdveZyf6lmb/XY13c0lSssiWXajWCw0Q.4","tags":[]}
-
-### 1.4.2. Data Space
+### Data Space
 
 Observed data are generally a set of numbers and are consolidated into an elements of data space $\mathbf{d}=(d_1,\dots,d_N)~\in\R^N$. Each datum is calculated using
 
-+++ {"oxa":"oxa:VNMrkxzChhdveZyf6lmb/58SCTuc4u4OkpuZPuoUB.5","tags":[]}
-
 ```{math}
-:label: 3ffde9a8
-
+\label{eq:datum}
 d_j=\mathcal{F}_j[m]
 ```
 
-+++ {"oxa":"oxa:VNMrkxzChhdveZyf6lmb/4kSVLuYWs1eP6YAygvA4.1","tags":[]}
-
 The subscript $j$ allows us to keep track of specifics for that datum, such as survey parameters, which field, etc.
 
-+++ {"oxa":"oxa:VNMrkxzChhdveZyf6lmb/GxWwK5fXdsCNhDBmI1dK.4","tags":[]}
-
-### 1.4.3. Forward Mapping Operators
+### Forward Mapping Operators
 
 The forward mapping operator $\mathcal{F}$ is problem dependent and can be formulated as an integral or differential operator. Fundamentally however, it is useful to distinguish between two types: linear and nonlinear operators. Linear operators are the easiest to deal with in an inverse problem and understanding them forms a solid foundation for attacking nonlinear inverse problems.
 
-+++ {"oxa":"oxa:VNMrkxzChhdveZyf6lmb/teCrqE51E9OHmLi76POI.4","tags":[]}
-
-#### 1.4.3.1 Linear and Nonlinear Mappings
+#### Linear and Nonlinear Mappings
 
 Let $f$ and $g$ be two elements of the model space and $\alpha$ and $\beta$ be two constants. A mapping $\mathcal{F}$ is linear if and only if
 
-+++ {"oxa":"oxa:VNMrkxzChhdveZyf6lmb/2612PkADvNiBlkg5RysF.7","tags":[]}
-
-```{math}
-:label: ec8a3fad
-
+$$
+\label{eq:linear-mapping}
 \mathcal{F}[\alpha f+\beta g]=\alpha\mathcal{F}[f]+\beta\mathcal{F}[g]
-```
-
-+++ {"oxa":"oxa:VNMrkxzChhdveZyf6lmb/Zzv6XxAJIjKIntg9DL4b.3","tags":[]}
+$$
 
 When this does not hold, the mapping is said to be nonlinear.
 
 Many linear functionals can be written in integral form. A generic representation that we will use is
 
-+++ {"oxa":"oxa:VNMrkxzChhdveZyf6lmb/kcG1fkQEwzcMhorgrH32.12","tags":[]}
-
-```{math}
-:label: f40ae85f
-
+$$
+\label{eq:kernel}
 d_j=\int^b_ag_j(x)m(x)dx
-```
+$$
 
-+++ {"oxa":"oxa:VNMrkxzChhdveZyf6lmb/Q62zNtrxrD4fYWSe68B7.4","tags":[]}
-
-where $d_j$ is the $j^{th}$ datum, $g_j$ is the associated kernel function, and $m$ is the model of interest. {eq}`f40ae85f` is a Fredholm equation of the second kind and it often appears in physical literature.
-
-+++ {"oxa":"oxa:VNMrkxzChhdveZyf6lmb/mIpjF5sWRaYY1EXnpFQU.3","tags":[]}
+where $d_j$ is the $j^{th}$ datum, $g_j$ is the associated kernel function, and $m$ is the model of interest. @eq:kernel is a Fredholm equation of the second kind and it often appears in physical literature.
 
 For example the equation for convolution,
 
-+++ {"oxa":"oxa:VNMrkxzChhdveZyf6lmb/bzvw8czOV3HO6mqz7Oet.6","tags":[]}
-
-```{math}
-:label: c61a0203
-
-y = m \otimes w
-```
-
-+++ {"oxa":"oxa:VNMrkxzChhdveZyf6lmb/y2pvzSGE7yzwJOI2AEQ8.1","tags":[]}
+$$ y = m \otimes w $$
 
 takes the following form
 
-+++ {"oxa":"oxa:VNMrkxzChhdveZyf6lmb/lO4LLkjjq7kbDfS6TCXp.7","tags":[]}
-
 ```{math}
-:label: a7524253
-
 y(t_j)=\int^{\infty}_{-\infty}m(\tau)w(t_j-\tau)d\tau
 ```
 
-+++ {"oxa":"oxa:VNMrkxzChhdveZyf6lmb/C6kzbMAo8xZWOJAbqCYK.4","tags":[]}
-
-In reflection seismology $m$ could be the reflectivity function, $w$ a wavelet, and $y$ an output seismogram. With reference to {eq}`f40ae85f`, each kernel is a time shifted version of $w$. Another form of our linear system ({eq}`f40ae85f`) is the Biot-Savart equation
-
-+++ {"oxa":"oxa:VNMrkxzChhdveZyf6lmb/5ifQPlmRIekmKf3BDcM0.9","tags":[]}
+In reflection seismology $m$ could be the reflectivity function, $w$ a wavelet, and $y$ an output seismogram. With reference to {eq}`eq:kernel`, each kernel is a time shifted version of $w$. Another form of our linear system ({eq}`eq:kernel`) is the [Biot-Savart](https://en.wikipedia.org/wiki/Biot%E2%80%93Savart_law) equation
 
 ```{math}
-:label: 32fe3486
-
-\vec{B}(\vec{r}_j)=\frac{\mu_0}{4\pi}\int\frac{\vec{J}(\vec{r}\prime)\times\hat{r}}{\left|\vec{r}_j-\vec{r}\prime\right|^2}
+\vec{B}(\vec{r}_j)=\frac{\mu_0}{4\pi}\int\frac{\vec{J}(\vec{r}')\times\hat{r}}{\left|\vec{r}_j-\vec{r}'\right|^2}
 ```
-
-+++ {"oxa":"oxa:VNMrkxzChhdveZyf6lmb/rWYokpEhRPJY21r7T4p1.2","tags":[]}
 
 Here the model is a vector, $m=\vec{J}$ where $\vec J$ is the current density, the kernel is the geometric function inside the integral and $\vec B$ is the magnetic flux density.
 
-+++ {"oxa":"oxa:VNMrkxzChhdveZyf6lmb/KV5MLwoPXVU4KlTV77YQ.4","tags":[]}
-
-We first show that {eq}`f40ae85f` is a linear mapping. Suppose we have two models $m_1(x)$ and $m_2(x)$, a kernel $g_j$ and two datum $d_j^{(1)}$ and $d_j^{(2)}$.
-
-+++ {"oxa":"oxa:VNMrkxzChhdveZyf6lmb/XsjJaecfwHID0KAINBLu.9","tags":[]}
+We first show that {eq}`eq:kernel` is a linear mapping. Suppose we have two models $m_1(x)$ and $m_2(x)$, a kernel $g_j$ and two datum $d_j^{(1)}$ and $d_j^{(2)}$.
 
 ```{math}
-:label: 9e1acfa8
-
 d_j^{(1)}=\int^b_a g_j(x)m_1(x)dx
 ```
 
-+++ {"oxa":"oxa:VNMrkxzChhdveZyf6lmb/T266ULKhnxY9ij5tql83.7","tags":[]}
-
 ```{math}
-:label: 89373b07
-
 d_j^{(2)}=\int^b_a g_j(x)m_2(x)dx
 ```
 
-+++ {"oxa":"oxa:VNMrkxzChhdveZyf6lmb/MO7eBvVyg8cmAi4XEC7j.2","tags":[]}
-
-The new datum, which is formed by a linear combination of the two models ({eq}`3ffde9a8` and {eq}`ec8a3fad`) is given by
-
-+++ {"oxa":"oxa:VNMrkxzChhdveZyf6lmb/LyvrSwMQ8phodV2Zk4sm.8","tags":[]}
+The new datum, which is formed by a linear combination of the two models (@eq:datum and @eq:linear-mapping) is given by
 
 ```{math}
-:label: fc8ce57f
-
-\begin{aligned}d_j=\int^b_a g_j(x)[\alpha & m_1(x) +\beta m_2(x)]\\ d_j=\alpha &d_j^{(1)}+\beta d_j^{(2)}\end{aligned}
+\begin{aligned}
+d_j =\int^b_a g_j(x)[\alpha & m_1(x) +\beta m_2(x)]     \\
+d_j =                \alpha & d_j^{(1)}+\beta d_j^{(2)}
+\end{aligned}
 ```
 
-+++ {"oxa":"oxa:VNMrkxzChhdveZyf6lmb/ibyUtdVKAfJUq1cKdNFU.4","tags":[]}
-
-and so the linearity condition in {eq}`f40ae85f` is satisfied. This is to be contrasted with an example like
-
-+++ {"oxa":"oxa:VNMrkxzChhdveZyf6lmb/DdipWkTJ9eCP4tao8oW9.8","tags":[]}
+and so the linearity condition in {eq}`eq:kernel` is satisfied. This is to be contrasted with an example like
 
 ```{math}
-:label: 7f61dce7
-
 d_j=\int^b_ag_j(x)m^2(x)dx
 ```
 
-+++ {"oxa":"oxa:VNMrkxzChhdveZyf6lmb/boXBd6npQ21lGJYI45vu.1","tags":[]}
-
 This is clearly a nonlinear relationship; if $m(x)$ increases by a factor of two then the datum in increased by a factor of four.
-
-+++ {"oxa":"oxa:VNMrkxzChhdveZyf6lmb/hQiUZV5SNJOilgvAbY2T.1","tags":[]}
 
 Another example of nonlinearity is that encountered in DC resistivity. The controlling differential equation is
 
-+++ {"oxa":"oxa:VNMrkxzChhdveZyf6lmb/FCouZX8qA3eeWl1zi0Zr.7","tags":[]}
-
 ```{math}
-:label: 0c8e0714
-
-\nabla\cdot\sigma\nabla V=-I\delta(\vec{r}-\vec{r}\prime)
+\nabla\cdot\sigma\nabla V=-I\delta(\vec{r}-\vec{r}')
 ```
-
-+++ {"oxa":"oxa:VNMrkxzChhdveZyf6lmb/qJDGd2c08DaR1a5dy4hl.3","tags":[]}
 
 where is the electrical conductivity, is the potential which are the data, and the right hand side is a source. Doubling is will not result in a doubling of V.
 
 The seismic refraction problem, is also a nonlinear mapping between travel time and velocity. Doubling the velocity of the earth will not increase the travel time by a factor of two. In fact, the majority of problem we deal with in geophysics are nonlinear.
 
-+++ {"oxa":"oxa:VNMrkxzChhdveZyf6lmb/jAoQMSJcF1GLLucMoosR.5","tags":[]}
-
-Throughout this module we will work with both linear and nonlinear problems. A simple insightful example appears in reflection seismology. It is the relationship between the rms velocity $V_{rms}$ and interval velocity $v_{int}$ {cite:p}`sheriff_exploration_1995`.
-
-+++ {"oxa":"oxa:VNMrkxzChhdveZyf6lmb/7vm3mQYoOAkNVRhsglMU.13","tags":[]}
+:::{prf:example} Reflection seismology
+:label: ex-reflection-seismology
+Throughout this module we will work with both linear and nonlinear problems. A simple insightful example appears in reflection seismology. It is the relationship between the rms velocity $V_{rms}$ and interval velocity $v_{int}$ [@sheriff_exploration_1995].
 
 ```{math}
-:label: a19b615c
-
+:label: eq:rms-velocity
 V^2_{rms}(t_j)=\frac{1}{t_j}\int^{t_{max}}_0 v^2_{int}(u)H(t_j-u)du
 ```
 
-+++ {"oxa":"oxa:VNMrkxzChhdveZyf6lmb/Rhk3F1nxOLRCb3GwrTfl.4","tags":[]}
-
-Here $H(t)$ is the Heaviside step function. If we think about the “model” as being $v_{int}$ then the problem is nonlinear. However, if we let $m=v^2_{int}$ then we have a linear relationship between data ($V^2_{rms}$) and $m$. Thus, sometimes a problem can be made linear just by redefining the variables. We note also that the independent variable is time, rather than depth. Thus to use this equation, where the velocity is $v(z)$ ,there has been a depth-to-time conversion. We will explore the consequences of these choices later but for now we’ll use the full nonlinear problem to show how nonuniqueness and ill-conditioning arises in the inverse problem.
+Here $H(t)$ is the Heaviside step function. If we think about the “model” as being $v_{int}$ then the problem is nonlinear. However, if we let $m=v^2_{int}$ then we have a linear relationship between data ($V^2_{rms}$) and $m$. Thus, sometimes a problem can be made linear just by redefining the variables. We note also that the independent variable is time, rather than depth. Thus to use this equation, where the velocity is $v(z)$, there has been a depth-to-time conversion. We will explore the consequences of these choices later but for now we’ll use the full nonlinear problem to show how nonuniqueness and ill-conditioning arises in the inverse problem.
+:::

--- a/content/forward-problem.md
+++ b/content/forward-problem.md
@@ -41,7 +41,7 @@ For our synthetic problem, we start by creating the function that we will later 
 
 +++ {"oxa":"oxa:VNMrkxzChhdveZyf6lmb/2L7K4fl4gBMQacD284lu.4","tags":[]}
 
-### 2.3.1. Mesh
+### Mesh
 
 In our next step we design a mesh on which our model is defined and on which all of the numerical computations are carried. We discretize our domain into $M$ cells of uniform thickness. If we think about the “x-direction” as being depth, then this discretization would be like having a layered earth.
 
@@ -59,7 +59,7 @@ Our “model” is now an M-length vector $\mathbf m = (m_1, m_2, …, m_M)$. In
 
 +++ {"oxa":"oxa:VNMrkxzChhdveZyf6lmb/qvGJ12IANr3L9Jk4UzMn.9","tags":[]}
 
-### 2.3.2. Kernels and Data
+### Kernels and Data
 
 Our goal is to carry out an experiment that produces data that are sensitive to the model shown in [Figure A](https://curvenote.com/oxa:VNMrkxzChhdveZyf6lmb/8WfrIYP5O9W6zakEQaa3.7). For our linear system ({eq}`f40ae85f`) this means choosing the kernel functions. In reality, these kernel functions are controlled by the governing physical equations and the specifics of the sources and receivers for the experiment. For our investigation we select oscillatory functions which decay with depth. These are chosen because they are mathematically easy to manipulate and they also have a connection with many geophysical surveys, for example, in a frequency domain electromagnetic survey a sinusoidal wave propagates into the earth and continually decays as energy is dissipated. The kernel $g_j(x)$ corresponding to $d_j$ is given by
 
@@ -141,7 +141,7 @@ $\mathbf{G}$ is an $N \times M$ matrix ($N$ data and $M$ model elements). Using 
 
 +++ {"oxa":"oxa:VNMrkxzChhdveZyf6lmb/BkSnNlITIGCWKaHVZM7F.3","tags":[]}
 
-### 2.3.3. Adding Noise
+### Adding Noise
 
 Until now, we have only calculated the data $\mathbf{d}$, but observed data $\mathbf{d}^{obs}$ contain additive noise,
 

--- a/content/geophysical-experiments.md
+++ b/content/geophysical-experiments.md
@@ -2,139 +2,89 @@
 title: Geophysical Experiments
 description: ''
 date: '2021-07-26T18:36:44.895Z'
-name: geophysical-experiments
 venue: Inverse Theory
-oxa: oxa:VNMrkxzChhdveZyf6lmb/plniE6ndBEU8rmtoxgIQ
-tags: []
-keywords: []
 ---
 
-+++ {"oxa":"oxa:VNMrkxzChhdveZyf6lmb/c2U4bqTNOFZAdAqg3b6b.9","tags":[]}
-
-In today’s world we are faced with many problems in which geophysics can play an important role. Some of these are visualized in the following [Figure %s](#geophysical-experiments-1) and include: (a) finding resources (minerals, water, hydrocarbons, geothermal energy); (b) environmental problems (contaminants, salt water, UXO, permafrost), (c) geotechnical (tunnels, infrastructure, slope stability); (d) natural hazards (earthquakes, volcanoes, tsunami); (e) subsurface storage (radioactive waste, CO2 sequestration, water).
-
-+++ {"oxa":"oxa:VNMrkxzChhdveZyf6lmb/ude7sgDinagoRoD7Mklx.9","tags":[]}
+In today’s world we are faced with many problems in which geophysics can play an important role. Some of these are visualized in the following [Figure %s](#geophysical-experiments-1) and include: (a) finding resources (minerals, water, hydrocarbons, geothermal energy); (b) environmental problems (contaminants, salt water, UXO, permafrost), (c) geotechnical (tunnels, infrastructure, slope stability); (d) natural hazards (earthquakes, volcanoes, tsunami); (e) subsurface storage (radioactive waste, CO$_2$ sequestration, water).
 
 ```{figure} images/VNMrkxzChhdveZyf6lmb-ude7sgDinagoRoD7Mklx-v9.png
 :name: geophysical-experiments-1
-:align: left
 :width: 100%
 
-Examples of geophysical experiments: (a) finding resources (minerals, water, hydrocarbons, geothermal energy); (b) environmental problems (contaminants, salt water, UXO, permafrost), (c) geotechnical (tunnels, infrastructure, slope stability); (d) natural hazards (earthquakes, volcanoes, tsunami); (e) subsurface storage (radioactive waste, CO2 sequestration, water).
+Examples of geophysical experiments: (a) finding resources (minerals, water, hydrocarbons, geothermal energy); (b) environmental problems (contaminants, salt water, UXO, permafrost), (c) geotechnical (tunnels, infrastructure, slope stability); (d) natural hazards (earthquakes, volcanoes, tsunami); (e) subsurface storage (radioactive waste, CO$_2$ sequestration, water).
 ```
 
-+++ {"oxa":"oxa:VNMrkxzChhdveZyf6lmb/sjqOFAQPVki2XkV5LXiW.4","tags":[]}
-
-To address these problems we need to be able to obtain information about the earth without directly sampling the domain. This is precisely the roll that geophysics can fulfill. A typical geophysical experiment is portrayed in {numref}`Figure %s <s8xtgmdDsqoM034PgCVu>` below.
-
-+++ {"oxa":"oxa:VNMrkxzChhdveZyf6lmb/s8xtgmdDsqoM034PgCVu.2","tags":[]}
+To address these problems we need to be able to obtain information about the earth without directly sampling the domain. This is precisely the roll that geophysics can fulfill. A typical geophysical experiment is portrayed in @fig:energy-sources below.
 
 ```{figure} images/VNMrkxzChhdveZyf6lmb-s8xtgmdDsqoM034PgCVu-v2.png
-:name: s8xtgmdDsqoM034PgCVu
+:label: fig:energy-sources
 :align: center
 :width: 50%
 
 Energy from a source is input to ground and propagates through the earth in a way that is governed by physical properties.
 ```
 
-+++ {"oxa":"oxa:VNMrkxzChhdveZyf6lmb/LGuTfU4jdLKMo8m8BRxq.2","tags":[]}
-
 Energy from a source is input to ground and propagates through the earth in a way that is governed by physical equations. The parameters in the governing equations are the physical properties of the earth (e.g. density, susceptibility, electrical conductivity, magnetic permeability, elastic parameters) and the distribution of these parameters determine how the energy flows. Sensors, usually at the surface, record potentials, fields and/or fluxes. These are the “observations” or “data”. In a general geophysical experiment we are given knowledge about the source, the equations governing the physics, and the observations. The goal is to extract information about the earth by recovering the distribution of the physical properties associated with the particular experiment.
 
 In the following we introduce some of the experiments we shall be working with.
 
-+++ {"oxa":"oxa:VNMrkxzChhdveZyf6lmb/4o0DUzTqxCe04JNWG7FK.5","tags":[]}
-
-### 1.2.1. Cross-well Tomography
+### Cross-well Tomography
 
 The physical property of interest is the seismic velocity $v$ or its reciprocal, slowness
 
-+++ {"oxa":"oxa:VNMrkxzChhdveZyf6lmb/1oG2RfNTKhSPAmCGyNA2.14","tags":[]}
-
-```{math}
-:label: f4385f45
-
-s=\frac{1}{v}
-```
-
-+++ {"oxa":"oxa:VNMrkxzChhdveZyf6lmb/5tlqlKajnE0OV6DgTxgc.1","tags":[]}
+$$ s=\frac{1}{v} $$
 
 Transmitters (Tx) in a borehole produce an acoustic signal which is measured by receivers (Rx) in another borehole. The governing equations are those used in seismology and involve density and the elastic constants. Here we simplify the physical problem and assume energy travels in straight rays. A value of a datum will be the time it takes for a seismic pulse to travel from a Tx to a Rx. Data can be plotted as a 2D image.
 
-+++ {"oxa":"oxa:VNMrkxzChhdveZyf6lmb/iTEJIqPO3N4ducDDDgPp.2","tags":[]}
-
 ```{figure} images/VNMrkxzChhdveZyf6lmb-iTEJIqPO3N4ducDDDgPp-v2.png
-:name: iTEJIqPO3N4ducDDDgPp
+:name: fig:experiments-cross-well
 :align: center
 :width: 80%
+
+Cross-well tomography
 ```
 
-+++ {"oxa":"oxa:VNMrkxzChhdveZyf6lmb/b0VHfSEMgIWT9ILdgItl.4","tags":[]}
-
-### 1.2.2. Direct Current (DC) Resistivity
+### Direct Current (DC) Resistivity
 
 The physical property is electrical conductivity $\sigma$ or its reciprocal, resistivity
 
-+++ {"oxa":"oxa:VNMrkxzChhdveZyf6lmb/mSbPSXOGQw2RminBZjJI.7","tags":[]}
-
-```{math}
-:label: 0e35ead3
-
-\rho = 1/\sigma
-```
-
-+++ {"oxa":"oxa:VNMrkxzChhdveZyf6lmb/fey5unR1OE1aavo1dbKD.1","tags":[]}
+$$ \rho = 1/\sigma $$
 
 Current $I$ is input to the earth using a generator and two electrodes and the electric potential difference $V$ is measured between two other electrodes. The data are converted to an apparent resistivity $\rho_a$ and plotted as a pseudo-section.
 
-+++ {"oxa":"oxa:VNMrkxzChhdveZyf6lmb/Iz816aCcjxd0kk3ZACHK.4","tags":[]}
-
 ```{figure} images/VNMrkxzChhdveZyf6lmb-Iz816aCcjxd0kk3ZACHK-v4.png
-:name: Iz816aCcjxd0kk3ZACHK
+:name: fig:experiments-dc
 :align: center
 :width: 80%
+
+Direct Current Resistivity
 ```
 
-+++ {"oxa":"oxa:VNMrkxzChhdveZyf6lmb/17dIxYl9fSNqXnHwj3C1.5","tags":[]}
-
-### 1.2.3. Airborne Time-Domain EM
+### Airborne Time-Domain EM
 
 The physical property is the electrical conductivity. The transmitter is a large loop of wire in which a current is flowing. In its simplest form, a steady-state current is turned off and a receiver, usually mounted beneath the aircraft, measures the resultant magnetic field or its time derivative. Data can be plotted as individual decays for a transmitter or in plan-view for a particular time channel.
 
-+++ {"oxa":"oxa:VNMrkxzChhdveZyf6lmb/qvZ9yDX3aasoCrlW9BrR.2","tags":[]}
-
 ```{figure} images/VNMrkxzChhdveZyf6lmb-qvZ9yDX3aasoCrlW9BrR-v2.png
-:name: qvZ9yDX3aasoCrlW9BrR
+:name: fig:experiments-aem
 :align: center
-:width: 50%
+:width: 60%
+Airborne Time-Domain EM
 ```
 
-+++ {"oxa":"oxa:VNMrkxzChhdveZyf6lmb/8ZsflHxiwLklS8kozxWT.4","tags":[]}
-
-### 1.2.4. Magnetics
+### Magnetics
 
 The physical property is magnetic susceptibility $\kappa$. This is related to magnetic permeability through the equation
 
-+++ {"oxa":"oxa:VNMrkxzChhdveZyf6lmb/5PN8xXuDlR25iGXFKu2l.7","tags":[]}
-
-```{math}
-:label: 3f2ba4e6
-
-\mu = \mu_0 (1 + \kappa)
-```
-
-+++ {"oxa":"oxa:VNMrkxzChhdveZyf6lmb/ts2p3gbJJfQxM6RHAz7S.1","tags":[]}
+$$ \mu = \mu_0 (1 + \kappa) $$
 
 The source is the earth’s magnetic field. This magnetizes earth materials and their resultant magnetic field can be measured with a magnetometer. The sensor can be on the surface of the earth or carried by various aircraft. The data are generally plotted in map form.
 
-+++ {"oxa":"oxa:VNMrkxzChhdveZyf6lmb/nR2mONada4kqsG1vxWwj.3","tags":[]}
-
 ```{figure} images/VNMrkxzChhdveZyf6lmb-nR2mONada4kqsG1vxWwj-v3.png
-:name: nR2mONada4kqsG1vxWwj
+:name: fig:experiments-magnetics
 :align: center
 :width: 60%
-```
 
-+++ {"oxa":"oxa:VNMrkxzChhdveZyf6lmb/yAAmTPb37lzB0GaB4Xp1.2","tags":[]}
+Magnetics
+```
 
 The above examples illustrate the relationship between earth physical property models, a geophysical experiment, and the resulting data. In each of these, the data on the right hand side of the figures, are generated by carrying out a forward simulation of the geophysical experiment. This is a well posed problem with a unique answer. In practise however, we are provided with the data and the ability to forward model and our goal is obtain the model on the left. This is the goal of the inverse problem.

--- a/content/index.md
+++ b/content/index.md
@@ -2,27 +2,17 @@
 title: Geophysical Inversions
 description: ''
 date: '2022-03-21T19:43:56.915Z'
-name: index
 venue: Introduction
-oxa: oxa:VNMrkxzChhdveZyf6lmb/RQnelOsxfgh5aLiamHZM
-tags: []
-keywords: []
 ---
-
-+++ {"oxa":"oxa:VNMrkxzChhdveZyf6lmb/HMu4VPfcRYpzk6vDxm0z.1","tags":[]}
 
 To understand our physical world we resort to experiments. Energy is input to an unknown system and data are recorded. The goal of inversion is to extract information about the system. In this chapter we look at the general inverse problem and, to provide context, present it within the discipline of geophysics. The procedures however are applicable to experiments in all areas of the physical sciences.
 
-+++ {"oxa":"oxa:VNMrkxzChhdveZyf6lmb/Hp4UMoL0UvKZFlV4fg1x.1","tags":[]}
-
-In today’s world we are faced with many problems in which geophysics can play an important role. Some of these are visualized in the following [Figure %s](#geophysical-experiments) and include: (a) finding resources (minerals, water, hydrocarbons, geothermal energy); (b) environmental problems (contaminants, salt water, UXO, permafrost), (c) geotechnical (tunnels, infrastructure, slope stability); (d) natural hazards (earthquakes, volcanoes, tsunami); (e) subsurface storage (radioactive waste, CO2 sequestration, water).
-
-+++ {"oxa":"oxa:VNMrkxzChhdveZyf6lmb/ude7sgDinagoRoD7Mklx.9","tags":[]}
+In today’s world we are faced with many problems in which geophysics can play an important role. Some of these are visualized in the following [Figure %s](#geophysical-experiments) and include: (a) finding resources (minerals, water, hydrocarbons, geothermal energy); (b) environmental problems (contaminants, salt water, UXO, permafrost), (c) geotechnical (tunnels, infrastructure, slope stability); (d) natural hazards (earthquakes, volcanoes, tsunami); (e) subsurface storage (radioactive waste, CO$_2$ sequestration, water).
 
 ```{figure} images/VNMrkxzChhdveZyf6lmb-ude7sgDinagoRoD7Mklx-v9.png
 :name: geophysical-experiments
 :align: left
 :width: 100%
 
-Examples of geophysical experiments: (a) finding resources (minerals, water, hydrocarbons, geothermal energy); (b) environmental problems (contaminants, salt water, UXO, permafrost), (c) geotechnical (tunnels, infrastructure, slope stability); (d) natural hazards (earthquakes, volcanoes, tsunami); (e) subsurface storage (radioactive waste, CO2 sequestration, water).
+Examples of geophysical experiments: (a) finding resources (minerals, water, hydrocarbons, geothermal energy); (b) environmental problems (contaminants, salt water, UXO, permafrost), (c) geotechnical (tunnels, infrastructure, slope stability); (d) natural hazards (earthquakes, volcanoes, tsunami); (e) subsurface storage (radioactive waste, CO$_2$ sequestration, water).
 ```

--- a/content/introduction-to-inversion.md
+++ b/content/introduction-to-inversion.md
@@ -2,69 +2,54 @@
 title: Introduction to Inversion
 description: ''
 date: '2021-07-26T18:52:15.216Z'
-name: introduction-to-inversion
 venue: Inverse Theory
-oxa: oxa:VNMrkxzChhdveZyf6lmb/6pwkTubIV6pNDL6nCruo
-tags: []
-keywords: []
 ---
 
-+++ {"oxa":"oxa:VNMrkxzChhdveZyf6lmb/8JBwT3IfaJIYtTURvEe7.11","tags":[]}
-
-Occasionally it is possible to infer useful information directly by looking at the data map. For instance, when a target body is situated in a homogeneous background, the data might indicate an anomaly that could be inferred to be a sought structure. Historically, many mineral deposits have been drilled on this type of analysis. In general however, this approach produces unsatisfactory results. A more responsible way to proceed is to implement a procedure to “invert” the data and find the physical property model that gave rise to the observations. The ideal procedure is illustrated in {numref}`Figure %s <cFtpNM4K3qAT83AO13wl>` below.
-
-+++ {"oxa":"oxa:VNMrkxzChhdveZyf6lmb/cFtpNM4K3qAT83AO13wl.2","tags":[]}
+Occasionally it is possible to infer useful information directly by looking at the data map. For instance, when a target body is situated in a homogeneous background, the data might indicate an anomaly that could be inferred to be a sought structure. Historically, many mineral deposits have been drilled on this type of analysis. In general however, this approach produces unsatisfactory results. A more responsible way to proceed is to implement a procedure to “invert” the data and find the physical property model that gave rise to the observations. The ideal procedure is illustrated in @fig:inversion-procedure below.
 
 ```{figure} images/VNMrkxzChhdveZyf6lmb-cFtpNM4K3qAT83AO13wl-v2.png
-:name: cFtpNM4K3qAT83AO13wl
+:name: fig:inversion-procedure
 :align: center
-:width: 50%
+:width: 70%
+Ideal inversion procedure
 ```
-
-+++ {"oxa":"oxa:VNMrkxzChhdveZyf6lmb/fld6WYGGqAQzuIJmY1ZH.1","tags":[]}
 
 In reality we have only a finite number of observations and they are inaccurate. On the other hand the earth can be exceedingly complicated and so it might be anticipated that the simple ideas in the figure can be easily achieved. The next sections are devoted to understanding the fundamental challenges of inversion, namely origins of the nonuniqueness in the solution. We use some simple problems in seismology to illuminate this understanding and help define our forward and inverse mappings as well as the lexicon we shall use throughout these chapters.
 
-+++ {"oxa":"oxa:VNMrkxzChhdveZyf6lmb/GmRMrh05UJqotz4VgxIl.19","tags":[]}
+(seismic-refraction-experiment)=
 
-### 1.3.1. Seismic Refraction Experiment
+### Seismic Refraction Experiment
 
-A common geophysical experiment that captures some of the essential ideas regarding an inverse problem is the seismic refraction survey. We consider a 1D earth in which the velocity increases with depth. Energy from a source propagates into the earth but continually refracts according to Snell’s law. It turns surface-ward at a critical point and returns to the surface where it can be recorded by a seismometer. The ray path in {numref}`Figure %s <iT2wXsnmJs6vxUjTWjIT>` shows how the energy travels.
-
-+++ {"oxa":"oxa:VNMrkxzChhdveZyf6lmb/iT2wXsnmJs6vxUjTWjIT.2","tags":[]}
+A common geophysical experiment that captures some of the essential ideas regarding an inverse problem is the seismic refraction survey. We consider a 1D earth in which the velocity increases with depth. Energy from a source propagates into the earth but continually refracts according to Snell’s law. It turns surface-ward at a critical point and returns to the surface where it can be recorded by a seismometer. The ray path in @fig:raypath shows how the energy travels.
 
 ```{figure} images/VNMrkxzChhdveZyf6lmb-iT2wXsnmJs6vxUjTWjIT-v2.png
-:name: iT2wXsnmJs6vxUjTWjIT
+:name: fig:raypath
 :align: center
-:width: 50%
+:width: 60%
+
+The ray paths show how the energy travels.
 ```
 
-+++ {"oxa":"oxa:VNMrkxzChhdveZyf6lmb/SxxXM4JHaaJd1KcNALeQ.3","tags":[]}
-
-If $x_j$ denotes the receiver location then the suite of seismograms at the associate receivers looks like that in {numref}`Figure %s <zCSw8Df3G21j9bg6vBN6>`.
-
-+++ {"oxa":"oxa:VNMrkxzChhdveZyf6lmb/zCSw8Df3G21j9bg6vBN6.2","tags":[]}
+If $x_j$ denotes the receiver location then the suite of seismograms at the associate receivers looks like that in @fig:seismograms.
 
 ```{figure} images/VNMrkxzChhdveZyf6lmb-zCSw8Df3G21j9bg6vBN6-v2.png
-:name: zCSw8Df3G21j9bg6vBN6
+:name: fig:seismograms
 :align: center
-:width: 40%
+:width: 70%
+
+Seismograms at the associate receivers from @fig:raypath.
 ```
 
-+++ {"oxa":"oxa:VNMrkxzChhdveZyf6lmb/tPXMqUCXBwTxTLeU3BFG.3","tags":[]}
-
-The time of the onset of the energy is of interest here; this is indicated as $t_j$ in the plot ({numref}`Figure %s <RJkB3T51OiJaZcXIe4vL>`). This value is equal to the integral of the slowness along the ray path. There is always uncertainty in picking these first arrivals because the arrivals don’t have a sharp onset and there is background noise on the seismic record. The data, along with estimated uncertainties, are plotted in the diagram below ({numref}`Figure %s <RJkB3T51OiJaZcXIe4vL>`).
-
-+++ {"oxa":"oxa:VNMrkxzChhdveZyf6lmb/RJkB3T51OiJaZcXIe4vL.3","tags":[]}
+The time of the onset of the energy is of interest here; this is indicated as $t_j$ in the plot (@fig:estimated-uncertainties). This value is equal to the integral of the slowness along the ray path. There is always uncertainty in picking these first arrivals because the arrivals don’t have a sharp onset and there is background noise on the seismic record. The data, along with estimated uncertainties, are plotted in the diagram below (@fig:estimated-uncertainties).
 
 ```{figure} images/VNMrkxzChhdveZyf6lmb-RJkB3T51OiJaZcXIe4vL-v3.png
-:name: RJkB3T51OiJaZcXIe4vL
+:name: fig:estimated-uncertainties
 :align: center
-:width: 50%
+:width: 60%
+
+Estimated uncertainties
 ```
 
-+++ {"oxa":"oxa:VNMrkxzChhdveZyf6lmb/mYd2QYvG98TjNHL7AAGt.5","tags":[]}
-
-### 1.3.2. Inverse problem
+### Inverse problem
 
 The inverse problem can be articulated as: “Given the survey information, data $d_j^{obs}$ (j=1,N), and an estimate of the uncertainty for each datum, what is the earth model, in this case the velocity structure $v(z)$, that produced these data?” An important component in addressing the inverse problem is that we have the capability to carry out a forward modelling. For this problem, for a given $v(z)$, how can we simulate the travel times.

--- a/content/inverse-problem-fundamental-challenges.md
+++ b/content/inverse-problem-fundamental-challenges.md
@@ -9,28 +9,23 @@ tags: []
 keywords: []
 ---
 
-+++ {"oxa":"oxa:VNMrkxzChhdveZyf6lmb/5p6zd29P0irLdHwChIYv.11","tags":[]}
-
-Inversion $\mathcal{F}^{-1}$ is the process of mapping from the data space $\mathcal{D}$ to the model space $\mathcal{M}$ $(\mathcal{F}^{-1}:~\mathcal{D}\rightarrow\mathcal{M})$, shown in {numref}`Figure %s <5BftNeWYsxYv8h6lhtx5>`.
-
-+++ {"oxa":"oxa:VNMrkxzChhdveZyf6lmb/5BftNeWYsxYv8h6lhtx5.2","tags":[]}
+Inversion $\mathcal{F}^{-1}$ is the process of mapping from the data space $\mathcal{D}$ to the model space $\mathcal{M}$ $(\mathcal{F}^{-1}:~\mathcal{D}\rightarrow\mathcal{M})$, shown in @fig:inverse-mapping.
 
 ```{figure} images/VNMrkxzChhdveZyf6lmb-5BftNeWYsxYv8h6lhtx5-v2.png
-:name: 5BftNeWYsxYv8h6lhtx5
+:name: fig:inverse-mapping
 :align: center
 :width: 50%
 
 Inversion $\mathcal{F}^{-1}$ is the process of mapping from the data space $\mathcal{D}$ to the model space $\mathcal{M}(\mathcal{F}^{-1}:~\mathcal{D}\rightarrow\mathcal{M})$.
 ```
 
-+++ {"oxa":"oxa:VNMrkxzChhdveZyf6lmb/uqWEH8OaD8K8aIJKplzd.5","tags":[]}
+Two fundamental challenges when inverting data is the ill-conditioning of the problem and nonuniqueness of the solution. We can obtain intuition for this by considering the relationship in seismology between rms velocity $V_{rms}$ and interval velocity $v_{int}$ from [](#ex-reflection-seismology) and @eq:rms-velocity. For this problem we define the following:
 
-Two fundamental challenges when inverting data is the ill-conditioning of the problem and nonuniqueness of the solution. We can obtain intuition for this by considering the relationship in seismology between rms velocity $V_{rms}$ and interval velocity $v_{int}$ originally presented in [1.3 Forward Mapping](oxa:VNMrkxzChhdveZyf6lmb/0VkRIdgDMntmQzhLzHiP '1.3 Forward Mapping')-{eq}`a19b615c`. For this problem we define the following:
+Forward Problem
+: $\mathcal{F}$: Given the model $v_{int}$ compute the data $V_{rms}$
 
-- **Forward Problem** $\mathcal{F}$: Given the model $v_{int}$ compute the data $V_{rms}$
-- **Inverse Problem** $\mathcal{F}^{-1}$: Given the data $V_{rms}$ compute the model $v_{int}$
-
-+++ {"oxa":"oxa:VNMrkxzChhdveZyf6lmb/ozWUHg27kr03Son7n3z8.1","tags":[]}
+Inverse Problem
+: $\mathcal{F}^{-1}$: Given the data $V_{rms}$ compute the model $v_{int}$
 
 Thus, given the data, $V_{rms}$, what is the velocity model, $v_{int}$ that produced the data? There are numerous questions that can be asked:
 
@@ -39,8 +34,6 @@ Thus, given the data, $V_{rms}$, what is the velocity model, $v_{int}$ that prod
 - Is the solution unique? - If you have found one candidate, are there others?
 - How do we handle nonuniqueness? - If there are multiple solutions, which model best reflects the subsurface physical property distribution?
 
-+++ {"oxa":"oxa:VNMrkxzChhdveZyf6lmb/sY7Ye0pfJgtKtLqeG4uk.1","tags":[]}
-
 The answers to these questions depend on the available data and it’s insightful to consider the following cases
 
 - infinite amount of accurate data (perfection ✨ )
@@ -48,29 +41,20 @@ The answers to these questions depend on the available data and it’s insightfu
 - finite amount of inaccurate data (reality 🌎 )
 - changes to the model due to a small perturbation of the data
 
-+++ {"oxa":"oxa:VNMrkxzChhdveZyf6lmb/VelHTm1PnjcptCJY1AxO.8","tags":[]}
-
-In the forward problem we are given $v_{int}$ and we calculate $V_{rms}$ “exactly” by carrying out the integration analytically ({eq}`cc63b0e8`) or numerically using extreme precision. The result is a function $V_{rms}(t)$ on the interval $[0, t_{max}]$.
-
-+++ {"oxa":"oxa:VNMrkxzChhdveZyf6lmb/TS1EFEmJCuYjiRf9oce2.9","tags":[]}
+In the forward problem we are given $v_{int}$ and we calculate $V_{rms}$ “exactly” by carrying out the integration analytically @eq:vrms-integration or numerically using extreme precision. The result is a function $V_{rms}(t)$ on the interval $[0, t_{max}]$.
 
 ```{math}
-:label: cc63b0e8
-
+:label: eq:vrms-integration
 V^2_{rms}(t)=\frac{1}{t}\int^{t_{max}}_0 v_{int}^2(u)H(t-u)du
 ```
 
-+++ {"oxa":"oxa:VNMrkxzChhdveZyf6lmb/WGo71zvzMK3kb1e1XMfb.1","tags":[]}
-
-We notice that each datum is an integral of $v_{int}$ and hence structure observed in $v_{int}$ will appear as smoothed structure in the data $V_{rms}$. That is, the forward operator is a “smoother”. As an example consider an interval $v_{int} = v_0 + a sin(2 \pi f t)$. The interval velocity model and data are shown below for the special case of xxxx
+We notice that each datum is an integral of $v_{int}$ and hence structure observed in $v_{int}$ will appear as smoothed structure in the data $V_{rms}$. That is, the forward operator is a “smoother”. As an example consider an interval $v_{int} = v_0 + a \sin(2 \pi f t)$. The interval velocity model and data are shown below for the special case of xxxx
 
 ```{figure} images/VNMrkxzChhdveZyf6lmb-Ca2uDOJsWjEA5cwlDOni-v1.png
 :name: ae6b407d
 :align: center
 :width: 70%
 ```
-
-+++ {"oxa":"oxa:VNMrkxzChhdveZyf6lmb/PFnAtoSIMS46aI5eKQ2u.1","tags":[]}
 
 As a general rule all forward modelling operators are smoothers and the issue is conceptualized in the figure below
 
@@ -80,15 +64,7 @@ As a general rule all forward modelling operators are smoothers and the issue is
 :width: 70%
 ```
 
-+++ {"oxa":"oxa:VNMrkxzChhdveZyf6lmb/Pa5NeI8W0JpU1Fp487U4.2","tags":[]}
-
-If the forward mapping F smooths, then the inverse operator F^-1must “roughen”. This is easily seen in our example where the analytic inverse
-
-+++ {"oxa":"oxa:VNMrkxzChhdveZyf6lmb/uFaTmz0sPKcluy5Srd4U.6","tags":[]}
-
-$\mathcal{F}^{-1}$ exists.
-
-+++ {"oxa":"oxa:VNMrkxzChhdveZyf6lmb/YN3xWuUFLvRxO1PyurOF.9","tags":[]}
+If the forward mapping $\mathcal{F}$ smooths, then the inverse operator $\mathcal{F}^{-1}$ must “roughen”. This is easily seen in our example where the analytic inverse $\mathcal{F}^{-1}$ exists.
 
 ```{math}
 :label: 815dcec5
@@ -96,11 +72,7 @@ $\mathcal{F}^{-1}$ exists.
 v_{int}=V_{rms}(t)\left(1+\frac{2tV'_{rms}(t)}{V_{rms}(t)}\right)^{\frac{1}{2}}
 ```
 
-+++ {"oxa":"oxa:VNMrkxzChhdveZyf6lmb/MBUIkiuuF4QO9Bnrjwms.4","tags":[]}
-
-We notice that there is a time derivate $V_{rms}^\prime (t)$ of the data. Differentiation is a roughening operator. Moreover this derivative is multiplied by $t$ which means that small changes in the data at later times will produce large changes in $v_{int}$. To explore the main concepts, we define an example for the rms velocity data,
-
-+++ {"oxa":"oxa:VNMrkxzChhdveZyf6lmb/BoYqRK5BjSO6jwAAB4AW.10","tags":[]}
+We notice that there is a time derivate $V_{rms}' (t)$ of the data. Differentiation is a roughening operator. Moreover this derivative is multiplied by $t$ which means that small changes in the data at later times will produce large changes in $v_{int}$. To explore the main concepts, we define an example for the rms velocity data,
 
 ```{math}
 :label: c2de4591
@@ -108,23 +80,13 @@ We notice that there is a time derivate $V_{rms}^\prime (t)$ of the data. Differ
 V_{rms}(t)=v_0+a\sin(2\pi ft)
 ```
 
-+++ {"oxa":"oxa:VNMrkxzChhdveZyf6lmb/ZBXjFzV8ccV0HOspODip.4","tags":[]}
-
 where $v_0$ is a constant, $a$ the amplitude of the sinusoid, and $f$ the frequency in Hz. The corresponding derivative of the data, required for the analytic inverse calculation ({eq}`815dcec5`) is
-
-+++ {"oxa":"oxa:VNMrkxzChhdveZyf6lmb/dB1iZKL3R6gRTlI9mOVG.9","tags":[]}
 
 ```{math}
 :label: 2f6367b7
 
 V'_{rms}(t)=2\pi af\cos(2\pi ft)
 ```
-
-+++ {"oxa":"oxa:VNMrkxzChhdveZyf6lmb/tqNqTtoTVeiFmAJdURL6.1","tags":[]}
-
-###
-
-+++ {"oxa":"oxa:VNMrkxzChhdveZyf6lmb/be0sepFJN3LNFJQS70CQ.1","tags":[]}
 
 We can solve equation (2) numerically by evaluating the integrand on a very fine mesh and using a quadrature integration and a finite difference for the derivative. The result is presented in Fig xx
 
@@ -134,15 +96,9 @@ We can solve equation (2) numerically by evaluating the integrand on a very fine
 :width: 70%
 ```
 
-+++ {"oxa":"oxa:VNMrkxzChhdveZyf6lmb/qKK0zJkt4m0DJMjwsKL4.1","tags":[]}
-
 The true and recovered interval velocity are identical.
 
-+++ {"oxa":"oxa:VNMrkxzChhdveZyf6lmb/rZBBRuSPdpXuCjQ6TceZ.1","tags":[]}
-
-+++ {"oxa":"oxa:VNMrkxzChhdveZyf6lmb/F03gjrzBIdp3emPh9ETl.6","tags":[]}
-
-### 1.5.1 Nonuniqueness
+## Nonuniqueness
 
 The above example illustrated the idealistic case where we have an infinite number of accurate data. We were able to recover the initial velocity model. We now explore the case where only a finite number of data exist. We do this by sampling $V_{rms}$ at $N$ times $t_j, (j=1,N)$, interpolate the data to obtain the function$, V_{rms}(t)$, as illustrated in the figure below.
 
@@ -168,15 +124,7 @@ In the figure below we show the models recovered by using a linear and a cubic s
 :width: 70%
 ```
 
-+++ {"oxa":"oxa:VNMrkxzChhdveZyf6lmb/xCfraYyphToLWaBABFif.2","tags":[]}
-
-+++ {"oxa":"oxa:VNMrkxzChhdveZyf6lmb/N64DvToncDWajXOApNkl.7","tags":[]}
-
-+++ {"oxa":"oxa:VNMrkxzChhdveZyf6lmb/BU6WZmJSykuMsVv83LLh.5","tags":[]}
-
-Whereas in {numref}`Figure %s <5BftNeWYsxYv8h6lhtx5>` the application of $\mathcal{F}^{-1}$ maps to a single point in model space, with a finite number of data, we have many possible models; these are indicated by the dark green subspace of the model space in {numref}`Figure %s <tfJv6scxau4VO7AZtTO3>`.
-
-+++ {"oxa":"oxa:VNMrkxzChhdveZyf6lmb/tfJv6scxau4VO7AZtTO3.2","tags":[]}
+Whereas in @fig:inverse-mapping the application of $\mathcal{F}^{-1}$ maps to a single point in model space, with a finite number of data, we have many possible models; these are indicated by the dark green subspace of the model space in {numref}`Figure %s <tfJv6scxau4VO7AZtTO3>`.
 
 ```{figure} images/VNMrkxzChhdveZyf6lmb-tfJv6scxau4VO7AZtTO3-v2.png
 :name: tfJv6scxau4VO7AZtTO3
@@ -184,19 +132,13 @@ Whereas in {numref}`Figure %s <5BftNeWYsxYv8h6lhtx5>` the application of $\mathc
 :width: 40%
 ```
 
-+++ {"oxa":"oxa:VNMrkxzChhdveZyf6lmb/uviwyCwHooverPPCsPSo.5","tags":[]}
-
 The nonuniqueness is exacerbated when we have a finite number of data contaminated with noise. As shown in {numref}`Figure %s <R7LoaGMcurI6TlSKSRyH>` below there are now more ways to interpolate the data and each interpolation will produce a different $v_{int}(t)$.
-
-+++ {"oxa":"oxa:VNMrkxzChhdveZyf6lmb/8zjjwtZbOi53B4Jx3zp0.1","tags":[]}
 
 ```{figure} images/VNMrkxzChhdveZyf6lmb-OaY83EoVsmYutnckX6Db-v1.png
 :name: a1e83824
 :align: center
 :width: 70%
 ```
-
-+++ {"oxa":"oxa:VNMrkxzChhdveZyf6lmb/O5UR8EX1aalPReLSmIuz.1","tags":[]}
 
 In the example below we add Gaussian noise with zero mean and standard deviation = 0.03 sec to the true data values. The point observations, along with error bars, are plotted in Fig xx. These data are linearly interpolated to generate $V_{rms}(t)$ for inversion. Even with small errors, the recovered model is exhibits considerable incorrect structure.
 
@@ -206,11 +148,7 @@ In the example below we add Gaussian noise with zero mean and standard deviation
 :width: 70%
 ```
 
-+++ {"oxa":"oxa:VNMrkxzChhdveZyf6lmb/NIR8aVm9C5uGUVWZ6O29.5","tags":[]}
-
 With respect to our mapping diagram, the inaccurate data to be inverted now populate the dark blue region of the data space and the inverse process maps to a larger, dark green, region of the model space ({numref}`Figure %s <CCyR4OOMNpenuGi2LINI>`).
-
-+++ {"oxa":"oxa:VNMrkxzChhdveZyf6lmb/CCyR4OOMNpenuGi2LINI.2","tags":[]}
 
 ```{figure} images/VNMrkxzChhdveZyf6lmb-CCyR4OOMNpenuGi2LINI-v2.png
 :name: CCyR4OOMNpenuGi2LINI
@@ -218,15 +156,11 @@ With respect to our mapping diagram, the inaccurate data to be inverted now popu
 :width: 50%
 ```
 
-+++ {"oxa":"oxa:VNMrkxzChhdveZyf6lmb/lJDQKHXKIoxNaMsnzTFC.5","tags":[]}
-
-### 1.5.2. Ill-conditioning
+### Ill-conditioning
 
 A second important aspect of the inverse problem is that of ill-conditioning. In most problems in geophysics, the forward operator is a smoothing operator. We saw that in the examples above but other insight arises from the fact that a geophysical datum often depends upon the physical properties in a volume of the subsurface. For instance, a gravity datum depends on the volumetric density distribution, or a DC potential depends upon all of the charges built up in the subsurface when a current is injected. So the data is effectively “averaging” the underlying physical property that we are attempting to find. The inverse problem must therefore “undo” this averaging. As in the previous examples, this often involves some type of differentiation of data to “roughen” the model. The practical question is whether that roughening results in model structures that are representative of the earth, or whether they present unrealistic structure. To quantify this we consider the following.
 
 Let
-
-+++ {"oxa":"oxa:VNMrkxzChhdveZyf6lmb/eWJc8RI8UDu2T19kMQSt.6","tags":[]}
 
 ```{math}
 :label: 1bc2c17d
@@ -234,11 +168,7 @@ Let
 d^{obs}=d^{true}+\delta d
 ```
 
-+++ {"oxa":"oxa:VNMrkxzChhdveZyf6lmb/Pdy4C81W4wlFSUo2wv9W.1","tags":[]}
-
 where $\delta d$ is a perturbation on the data. Let
-
-+++ {"oxa":"oxa:VNMrkxzChhdveZyf6lmb/TaXITd9sMowbH20A8EKE.6","tags":[]}
 
 ```{math}
 :label: d73ceb50
@@ -246,11 +176,7 @@ where $\delta d$ is a perturbation on the data. Let
 \mathcal{F}^{-1}[d^{true}]=m_c
 ```
 
-+++ {"oxa":"oxa:VNMrkxzChhdveZyf6lmb/2boWVqpPu3q9t6hq0mt5.2","tags":[]}
-
 where $m_c$ is the constructed model. We can then write
-
-+++ {"oxa":"oxa:VNMrkxzChhdveZyf6lmb/yJTiTKTETafVxEIFbai8.8","tags":[]}
 
 ```{math}
 :label: 5c78d503
@@ -258,13 +184,9 @@ where $m_c$ is the constructed model. We can then write
 \mathcal{F}^{-1}[d^{obs}]=\mathcal{F}^{-1}[d^{true}+\delta d]=m_c+\delta m
 ```
 
-+++ {"oxa":"oxa:VNMrkxzChhdveZyf6lmb/mG55hpI5lTCqKIYGJv2v.4","tags":[]}
-
 Suppose $\|\delta d\|$ is small, does that mean $\|\delta m\|$ is small? If it is not, then we will say that the problem is “ill-conditioned”.
 
 Using the relationship between $V_{rms}$ and $v_{int}$ in {eq}`815dcec5` suppose that our data is a constant, $V_{rms}=v_0$. The resulting model would be that same constant, $v_{int}(t) = v_0$. We can add a small sinusoidal perturbation to the data $(\delta d=a\sin(2\pi ft))$, such that the data is defined in {eq}`c2de4591`. Despite the addition of small perturbation to the data, the resulting perturbation to the model $\delta m$ is not small, as shown in {eq}`2f6367b7`, and thus
-
-+++ {"oxa":"oxa:VNMrkxzChhdveZyf6lmb/LvqtQqFT2lBARuGaF4jb.5","tags":[]}
 
 ```{math}
 :label: ec61be48
@@ -272,10 +194,6 @@ Using the relationship between $V_{rms}$ and $v_{int}$ in {eq}`815dcec5` suppose
 \delta v_{int}\propto \sqrt{\frac{fta}{v_0}}
 ```
 
-+++ {"oxa":"oxa:VNMrkxzChhdveZyf6lmb/cuhkHQTICcIaX07Hxilh.1","tags":[]}
-
 Therefore $\delta v_{int}$ can be made arbitrarily large even if $a$ is small; we only need to increase the product $tf$. This inverse problem is considered ill-conditioned.
-
-+++ {"oxa":"oxa:VNMrkxzChhdveZyf6lmb/jWbtZAiUHnqlljFzy7AE.2","tags":[]}
 
 ## Hands on with the app

--- a/content/inverse-theory-overview.md
+++ b/content/inverse-theory-overview.md
@@ -2,15 +2,9 @@
 title: Inverse Theory Overview
 description: ''
 date: '2021-02-15T23:27:01.295Z'
-name: inverse-theory-overview
 venue: Inverse Theory
-oxa: oxa:VNMrkxzChhdveZyf6lmb/n4krShPqra002w55QQvU
-tags: []
-keywords: []
 thumbnail: thumbnails/inverse-theory-overview.png
 ---
-
-+++ {"oxa":"oxa:VNMrkxzChhdveZyf6lmb/XSYCHYKdMRyKsum4mKdy.8","tags":[]}
 
 To understand our physical world we resort to experiments. Energy is input to an unknown system and data are recorded. The goal of inversion is to extract information about the system. In this chapter we look at the general inverse problem and, to provide context, present it within the discipline of geophysics. The procedures however are applicable to experiments in all areas of the physical sciences.
 
@@ -18,18 +12,22 @@ The goals for this chapter are to view the forward and inverse mappings as conne
 
 In this overview we provide a simple interactive example with the corresponding Jupyter notebook, to illustrate why the goal of obtaining the sought model, with knowledge of the data alone, is “ill-posed” and generally “ill-conditioned”. This understanding serves as an introduction to our next chapter regarding how to solve an inverse problem using optimization.
 
-+++ {"oxa":"oxa:VNMrkxzChhdveZyf6lmb/4PR94mipvmAPx1QslbQ0.3","tags":[]}
-
 ## Contents
 
-**1.1. Geophysical Experiment:** Defining the geophysical problems we intend to model. For each problem, this includes defining the survey (sources and receivers), the data and the diagnostic physical property.
+[Geophysical Experiment](./geophysical-experiments.md)
+: Defining the geophysical problems we intend to model. For each problem, this includes defining the survey (sources and receivers), the data and the diagnostic physical property.
 
-**1.2. Introduction to Inversion:** Providing a basic conceptual description of geophysical inversion.
+[Introduction to Inversion](./introduction-to-inversion.md)
+: Providing a basic conceptual description of geophysical inversion.
 
-**1.3. Forward Mapping:** Representing the forward problem as a discrete mapping from the model space to the data space.
+[Forward Mapping](./forward-mapping.md)
+: Representing the forward problem as a discrete mapping from the model space to the data space.
 
-**1.4. Inverse Problem Fundamental Challenges:** Exploring the effects of non-uniqueness and ill-conditioning encountered when solving geophysical inverse problems.
+[Inverse Problem Fundamental Challenges](./inverse-problem-fundamental-challenges.md)
+: Exploring the effects of non-uniqueness and ill-conditioning encountered when solving geophysical inverse problems.
 
-**1.5. Solving an Ill-Posed Problem:** Overview of approaches for solving ill-posed (non-unique and/or ill-conditioned) inverse problems.
+[Solving an Ill-Posed Problem](./solving-an-ill-posed-problem.md)
+: Overview of approaches for solving ill-posed (non-unique and/or ill-conditioned) inverse problems.
 
-**1.6. Summary:** An overview of what was learned in this chapter.
+[Summary](./theory-summary.md)
+: An overview of what was learned in this chapter.

--- a/content/inversion-with-svd.md
+++ b/content/inversion-with-svd.md
@@ -2,18 +2,10 @@
 title: Inversion with SVD
 description: ''
 date: '2021-03-08T22:43:15.613Z'
-name: inversion-with-svd
 venue: Inversion with SVD
-oxa: oxa:VNMrkxzChhdveZyf6lmb/USqfjE3Naoc2aE60TB28
-tags: []
-keywords: []
 ---
 
-+++ {"oxa":"oxa:VNMrkxzChhdveZyf6lmb/fq7UMbsL4qiBKwEVL8dL.1","tags":[]}
-
 Fundamental understanding about non-uniqueness and ill-conditioning of the linear inverse problem is readily achieved with the aid of Singular Value Decomposition (SVD). In this chapter we show how this decomposition ……
-
-+++ {"oxa":"oxa:VNMrkxzChhdveZyf6lmb/pTk3XNR6MHbTlZO53TfJ.1","tags":[]}
 
 # Recall
 
@@ -65,15 +57,11 @@ Typically $M>N$ creating an underdetermined problem, which has infinitely many s
 
 In this chapter we consider the question: How do we understand and deal with these elements?
 
-+++ {"oxa":"oxa:VNMrkxzChhdveZyf6lmb/dhA62zqa7KeMhmdCeBHh.1","tags":[]}
-
 # Solving $\mathbf{Gm}=\mathbf{d}$
 
 Given $\mathbf{Gm}=\mathbf{d}$ and knowing $\mathbf{G}\in\R^{N\times M}$, $\mathbf{m}\in\R^M$, and $\mathbf{d}\in\R^N$, we want to write $\mathbf{m}=\mathbf{G}^{-1}\mathbf{d}$, but $\mathbf{G}$ is not sparse and $\mathbf{G}^{-1}$ does not exist.
 
 For example, if we write $Gm=d$ as $m_1+2m_2=2$ such that $G=[1,2]$, $d=2$, and $m=(m_1,m_2)^T$ and consider $m=G^{-1}d$.
-
-+++ {"oxa":"oxa:VNMrkxzChhdveZyf6lmb/KzvyCZTmXHqih4U7Bm2E.1","tags":[]}
 
 # Singular Value Decomposition
 
@@ -98,8 +86,6 @@ $\mathbf{V}_p =\begin{pmatrix} |& & | \\ \mathbf{v}_1 & \dots & \mathbf{v}_p\\ |
 $\mathbf{m}^{\parallel}$: activated portion of the model space
 
 $\mathbf{m}^{\perp}$: annihilator space
-
-+++ {"oxa":"oxa:VNMrkxzChhdveZyf6lmb/szZtTOGPMD45hNRU5y85.1","tags":[]}
 
 ## Solving with SVD
 
@@ -127,8 +113,6 @@ $\phi_m=\|\mathbf{m}\|^2$
 
 $\mathbf{m}_c=\sum^p_{i=1}\left(\frac{\mathbf{u}_i^T\mathbf{d}}{\lambda_i}\right)\mathbf{v}_i$
 
-+++ {"oxa":"oxa:VNMrkxzChhdveZyf6lmb/cZ94ok80H1vO52eoVpg6.1","tags":[]}
-
 ## Ill-conditionedness
 
 $\mathbf{m}_c=\sum^p_{i=1}\left(\frac{\mathbf{u}_i^T\mathbf{d}}{\lambda_i}\right)\mathbf{v}_i$
@@ -140,8 +124,6 @@ Small singular value $\leftrightarrow$ highly oscillatory, large amplitude of no
 :align: center
 :width: 70%
 ```
-
-+++ {"oxa":"oxa:VNMrkxzChhdveZyf6lmb/5OAKjacU8FF7Oy8E0Hav.1","tags":[]}
 
 ## Truncated SVD
 
@@ -164,8 +146,6 @@ Truncated SVD treats/takes care of issues caused by non-uniqueness and ill-condi
 :align: center
 :width: 70%
 ```
-
-+++ {"oxa":"oxa:VNMrkxzChhdveZyf6lmb/5r5zjZO17kVqbgjAan8m.1","tags":[]}
 
 ## Consider Tikhonov Solution
 
@@ -197,8 +177,6 @@ Solve $\mathbf{Am}=\mathbf{b}$, letting $\mathbf{A}=\mathbf{G}^T\mathbf{G}+\beta
 :width: 70%
 ```
 
-+++ {"oxa":"oxa:VNMrkxzChhdveZyf6lmb/u9rcqwtNIqmxGeqCwbve.1","tags":[]}
-
 ### Tikhonov, TSVD, weighted TSVD
 
 $(\mathbf{G}^T\mathbf{G}+\beta\mathbf{I})\mathbf{m}=\mathbf{G}^T\mathbf{d}$
@@ -218,8 +196,6 @@ $t_i=\frac{\lambda_i^2}{\lambda_i^2+\beta}$
 :align: center
 :width: 70%
 ```
-
-+++ {"oxa":"oxa:VNMrkxzChhdveZyf6lmb/LK5qEMF3oDJCsrCdXkSz.1","tags":[]}
 
 # Summary
 

--- a/content/linear-l2-norm-inverson.md
+++ b/content/linear-l2-norm-inverson.md
@@ -1,43 +1,18 @@
 ---
 title: Linear L2-norm Inversion
 description: ''
-authors:
-  - userId: kJ1wjvSFymWWBKGfgdlwXFWwwkw2
-    nameParsed:
-      literal: Douglas Oldenburg
-      given: Douglas
-      family: Oldenburg
-    name: Douglas Oldenburg
-    corresponding: false
-    roles: []
-    affiliations: []
-    id: contributors-generated-uid-0
 date: '2021-02-05T05:11:21.278Z'
-name: linear-l2-norm-inverson
 venue: Linear L2-norm Inversion
-oxa: oxa:VNMrkxzChhdveZyf6lmb/Y0Box7MOUPDD3MnSXT0H
-tags: []
-keywords: []
 thumbnail: thumbnails/linear-l2-norm-inverson.png
 ---
 
-+++ {"oxa":"oxa:VNMrkxzChhdveZyf6lmb/qyT1iwUBteJU2zHFC7zg.4","tags":[]}
-
 In this chapter we put the principles of Tikhonov inversion into practice and address the numerical under-pinnings for solving the linear problem using L2 norms for the misfit and model regularization. The function to be minimized is a quadratic and a solution the inverse problem can be achieved in a single step by solving a linear system of equations. We use our flowchart to keep us on-track as we step through the basic elements. For each element we provide background that will be of use when attacking any inverse problem. These include issues about the noise and misfit, the model norm, how to solve the system numerically, how to choose a tradeoff parameter, and some basic principles for evaluating the results of the inversion and potentially carrying out an inversion with revised parameters.
 
-+++ {"oxa":"oxa:VNMrkxzChhdveZyf6lmb/bisO6VgGL83cBPTxg5ZT.1","tags":[]}
-
 # Key Points
-
--
-
-+++ {"oxa":"oxa:VNMrkxzChhdveZyf6lmb/yW8HIDCjGid4XttQBuJi.1","tags":[]}
 
 ### Workflow for Inversion
 
 A successful inversion of any data set requires a workflow in which each element can be critically addressed. The quality of a final result depends upon how well each of these is implemented and in the following we elaborate on each component.
-
-+++ {"oxa":"oxa:VNMrkxzChhdveZyf6lmb/Y1lrL2Ti6uotZ7Per2zY.11","tags":[]}
 
 ```{figure} images/VNMrkxzChhdveZyf6lmb-KV36nNTMujTCmChumcXX-v1.png
 :name: ab68fc54
@@ -50,8 +25,6 @@ A successful inversion of any data set requires a workflow in which each element
 
 ```
 
-+++ {"oxa":"oxa:VNMrkxzChhdveZyf6lmb/ccLlbxa0ypqI4E370XE1.1","tags":[]}
-
 ### Inputs
 
 There are three boxes under the “Inputs” heading.
@@ -59,8 +32,6 @@ There are three boxes under the “Inputs” heading.
 #### Field Observations and error estimates.
 
 This includes the obvious components such as knowing your survey acquisition parameters, the fields that are measured, and estimates of the uncertainties in the data. For instance, in a DC resistivity survey we need to know the locations of the current and potential electrodes, the transmitter current, how the electric potentials at the receiver electrodes are converted from the repetitions of the bi-polar transmitter current and stacked and subsequently processed to give a datum that corresponds to an ideal step-on transmitter current. Field logs are often required to reveal where challenges were encountered; for example electrodes could not be placed in their proposed locations because of trees, gullies, asphalt roads etc. These will later have to be modelled within the inversion, or included as “noise” in uncertainty estimates. Lastly, it is essential that all details about the subsequent processing of the data are known and importantly the final units of the data. Determining final units of the data and normalizations is traditionally one of the major hurdles for getting started on an inversion.
-
-+++ {"oxa":"oxa:VNMrkxzChhdveZyf6lmb/qPubfi2h5Q2yISE7gWhH.3","tags":[]}
 
 #### Prior Knowledge
 
@@ -70,13 +41,9 @@ Assembling your a priori knowledge about the project area is crucial. This inclu
 - when linked with the survey and forward modelling, it provides a set of predicted data that can be used as a first order check about normalizations of the data
 - compiling a priori information into a reference model often clarifies what is known, and what is unknown, about the earth model. This in turn helps generate objectives for carrying out the inversion. That is, what question about the earth do we want answered when the geophysical data are included in the inversion. This becomes important in a later box in the flowchart where the parameters for inversion are specified.
 
-+++ {"oxa":"oxa:VNMrkxzChhdveZyf6lmb/JtAQKDezULk6Y06JayiH.3","tags":[]}
-
 #### Forward modelling
 
 The crucial component for solving an inverse problem is the ability to carry out a forward modelling to simulate data from an input model. That is, we want to evaluate
-
-+++ {"oxa":"oxa:VNMrkxzChhdveZyf6lmb/Iv43QHUhUicMsAvpWgAb.6","tags":[]}
 
 ```{margin}
 **Equation 1.4** Forward mapping operation $\mathcal{F}$ applied to an element of the model space $m$ to calculate the corresponding element in the data space $d$.
@@ -85,17 +52,11 @@ The crucial component for solving an inverse problem is the ability to carry out
 
 $$\mathcal{F}[m] = d$$
 
-+++ {"oxa":"oxa:VNMrkxzChhdveZyf6lmb/dDrrkOV8KW4IOr5YFf4S.1","tags":[]}
-
 The forward modelling needs to be accurate, which in practice means that numerical errors are less than the “noise” in the data. It must also be efficient since the forward modelling must be done many times during the course of the inversion.
 
 To numerically simulate data we generally discretize the problem onto a mesh (1D, 2D, 3D). The cells must be sufficiently small and extend to large enough distances so that relevant boundary conditions are satisfied and that the forward modelling operator produces sufficiently accurate results. In the case of our 1D problem, you can experiment with the accuracy of the simulation by comparing data generated with a very large number of cells with data produced by discretizing with fewer cells. The inaccuracies in this case also arise because of the way the integration of the kernels is carried out for each cell; here, a mid-point rule is chosen. This becomes less accurate as the size of the cells increases and/or the frequency of the kernel function increases.
 
-+++ {"oxa":"oxa:VNMrkxzChhdveZyf6lmb/qKhqiiaLOt1C8DHFZqqX.1","tags":[]}
-
 ### Define Inversion parameters
-
-+++ {"oxa":"oxa:VNMrkxzChhdveZyf6lmb/nodi2xPSV86mhnFBb0sm.1","tags":[]}
 
 ```{figure} images/VNMrkxzChhdveZyf6lmb-QxW3uQzDww1XhwRlz16b-v1.png
 :name: 0772fe92
@@ -108,8 +69,6 @@ To numerically simulate data we generally discretize the problem onto a mesh (1D
 
 ```
 
-+++ {"oxa":"oxa:VNMrkxzChhdveZyf6lmb/owCYD2sbtjj60BmtVakL.4","tags":[]}
-
 ###
 
 ```{figure} images/VNMrkxzChhdveZyf6lmb-QxW3uQzDww1XhwRlz16b-v1.png
@@ -120,13 +79,9 @@ To numerically simulate data we generally discretize the problem onto a mesh (1D
 
 The mesh used for forward simulation is designed so that simulated results are high quality. We could use the same mesh for the inverse problem, as done in the notebook, but that is not necessary. Our inversion mesh could be composed of fewer cells, either by fixing the values of some cells and not including them in the inversion, or by homogenizing groups of cells. Moreover, the model parameters used for inversion might be different from those used in the forward simulation. As an example, in an electromagnetic problem the basic equations and forward simulation uses the electrical conductivity $\sigma$ so $\mathcal F[\sigma] =d$. But electrical conductivity is positive and varies over orders of magnitude. Both of these attributes can be handled readily by having the inversion parameters be $m = \log (\sigma)$.
 
-+++ {"oxa":"oxa:VNMrkxzChhdveZyf6lmb/nP5XjTHKG4E0rJ19k6jl.2","tags":[]}
-
 ### Misfit criterion
 
 As discussed in the Tikhonov section we need some way to evaluate how close the predicted data are to the observations and then a criterion for choosing a target value for that misfit.
-
-+++ {"oxa":"oxa:VNMrkxzChhdveZyf6lmb/HtD9gAa5b4qMOmOgpind.1","tags":[]}
 
 ```{figure} images/VNMrkxzChhdveZyf6lmb-9lu75re1S6DPdYwYZfcl-v1.png
 :name: 60b17fdb
@@ -134,19 +89,13 @@ As discussed in the Tikhonov section we need some way to evaluate how close the 
 :width: 50%
 ```
 
-+++ {"oxa":"oxa:VNMrkxzChhdveZyf6lmb/Kfs2wU8VYaKwlZfzYJtD.5","tags":[]}
-
 Our observed datum is defined such that $d_j^{obs}=\mathcal{F}_j\left[m\right]+\tilde{n}_j$ where $\mathcal{F}_j\left[m\right]$ is our mathematical representation of the forward operator and $\tilde{n}_j$ is the additive noise. We want to find a model $m$ that gave rise to the data $d^{obs}$. The noise $\tilde n_j$ is a challenging element to quantify. It is built up from modelling errors and well as traditional experimental noise that is associated with any survey.
 
 We first address modelling errors. The forward modelling for our physical system is as $\mathcal{F}_j\left[m\right]=F_j\left(m\right)$ where $m$ is a function and $\mathcal{F}[ \cdot]$ includes the complete physics of our problem. Our numerical forward operator $F_j[\cdot]$ does not represent that exactly. Thus $\mathcal{F}_j\left[m\right]=F_j\left(m\right)+\hat{n}_j$, where $\hat{n}_j$ are the discrepancies between the forward operator $F_j\left(m\right)$ and our mathematical representation $\mathcal{F}_j\left[m\right]$. These discrepancies are due to a variety of factors and assumptions such as the wrong dimension (1-D, 3-D), incomplete physics, or discretization errors. The statistics of these discrepancies are problem dependent and not easily quantified.
 
 In addition to modelling errors there are also additional additive noise \\$\hat{n}_j\hat{n}_j$ that arises from the survey. Rewriting our observed datum with the numerical forward operator, $d_j^{obs}=F_j\left(m\right)+\hat{n}_j+\tilde{n}_j$. We can combine the additive noise in the observed data $\tilde{n}_j$ and the discrepancies in the forward operator $\hat{n}_j$ into one statistical variable that accounts for all the noise in the system $n_j$. Our observed datum is now $d_j^{obs}=F_j\left(m\right)+n_j$. Clearly the statistics of $n_j$ is challenging to quantify but for our present purposes, we assume that each is characterized by Gaussian distribution with a zero mean and a standard deviation $\epsilon_j$, that is $N[0, \epsilon_j]$. This is a huge simplification but we can take some comfort in the Central Limit Theorem (ref).
 
-+++ {"oxa":"oxa:VNMrkxzChhdveZyf6lmb/jV3SX5PvBeQaemtUM9X3.3","tags":[]}
-
 Consider a random variable $x_j \in \mathcal{N}(0,1)$. By taking a sum of squares we then define a new random variable, $\chi^2_N=\sum^N_{j=1}x^2_j$, which follows a chi-squared distribution with N-degrees of freedom. For this distribution the expected value is $E(\chi^2_N)=N$, the variance is $Var(\chi^2_N)=2N$, and the standard deviation is $std(\chi^2_N)=\sqrt{2N}$. In the next section we shall use $\chi^2_N$ as a misfit function for our inverse problem and its expected value as a target value.
-
-+++ {"oxa":"oxa:VNMrkxzChhdveZyf6lmb/nsUE938UjPGW8EJikcgU.4","tags":[]}
 
 ### Misfit Function
 
@@ -176,8 +125,6 @@ Assigning uncertainties to data is a critical step in a practical inversion. Thi
 
 : Below we outline some The suggestion of $\varepsilon_j=\%\left|d_j^{obs}\right|+floor$ and uncertainty is a good starting point.
 
-+++ {"oxa":"oxa:VNMrkxzChhdveZyf6lmb/yWKENHDODz7kj2oKudTF.2","tags":[]}
-
 ### Model Objective Function
 
 The model objective function can consist of one or a combination of the following model norms, discussed previously in LINK TO Linear Tikhonov Inversion:
@@ -200,8 +147,6 @@ $$\phi_m=\alpha_s\int (m-m^{ref})^2 dx+\alpha_x\int (\frac{d(m-m^{ref})}{dx})^2 
 
 $$\phi_m=\alpha_s\left|\left|\mathbf{W}_s(\mathbf{m}-\mathbf{m}^{ref})\right|\right|^2+\alpha_x\left|\left|\mathbf{W}_x(\mathbf{m})\right|\right|^2$$
 
-+++ {"oxa":"oxa:VNMrkxzChhdveZyf6lmb/eIJWpjjEe1mWIw8tstnC.3","tags":[]}
-
 ### Perform Inversion
 
 We combine the data misfit and model objective functions into the objective function $\phi(\mathbf{m})=\frac{1}{2}\left|\left|\left(\mathbf{Gm}-\mathbf{d}^{obs}\right)\right|\right|^2_2+\frac{1}{2}\left|\left|\mathbf{W}_m\left(\mathbf{m}-\mathbf{m}_{ref}\right)\right|\right|^2_2$.
@@ -211,8 +156,6 @@ To solve the quadratic objective function for a single variable we calculate the
 $$\begin{aligned} \mathbf{g}&=\nabla_m\phi\\ &= \mathbf{G}^T\mathbf{W}_d^T\mathbf{W}_d\left(\mathbf{Gm}-\mathbf{d}^{obs}\right)+\beta\mathbf{W}_m^T\mathbf{W}_m\left(\mathbf{m}-\mathbf{m}_{ref}\right)\\ \mathbf{g}&=0\\ \left(\mathbf{G}^T\mathbf{W}_d^T\mathbf{W}_d\mathbf{G}+\beta\mathbf{W}_m^T\mathbf{W}_m\right) &= \mathbf{G}^T\mathbf{W}_d^T\mathbf{W}_d\mathbf{d}^{obs}+\beta\mathbf{W}_m^T\mathbf{W}_m\mathbf{m}_{ref}\end{aligned}$$
 
 Consider the matrix vector equation $\mathbf{Am}=\mathbf{b}$, where $\mathbf{A}\in\R ^{M\times M}$ is full rank and $\mathbf{m},\mathbf{b}\in\R ^M$, then the above can then be considered in the form $\mathbf{m}=\mathbf{A}^{-1}\mathbf{b}$.
-
-+++ {"oxa":"oxa:VNMrkxzChhdveZyf6lmb/BASuKzbZBUv01KO4tpR0.1","tags":[]}
 
 ### Managing Misfit with $\beta$
 

--- a/content/linear-tikhonov-inversion.md
+++ b/content/linear-tikhonov-inversion.md
@@ -2,15 +2,9 @@
 title: Linear Tikhonov Inversion
 description: ''
 date: '2021-01-18T19:49:36.029Z'
-name: linear-tikhonov-inversion
 venue: Linear Tikhonov Inversion
-oxa: oxa:VNMrkxzChhdveZyf6lmb/0OWJFcTbsHudpX5JjU0V
-tags: []
-keywords: []
 thumbnail: thumbnails/linear-tikhonov-inversion.png
 ---
-
-+++ {"oxa":"oxa:VNMrkxzChhdveZyf6lmb/EHXIuqY6xzY26VQZHU3K.5","tags":[]}
 
 ## Introduction
 
@@ -18,23 +12,17 @@ In this chapter we present the basic elements for how an inverse problem can be 
 
 The inverse problem has many elements and a solution is best achieved by adhering to the workflow shown in {numref}`Figure %s <KV36nNTMujTCmChumcXX>` below. Throughout this chapter we investigate each of these steps and illustrate the concepts with a simple linear problem. Jupyter notebooks are provided so that the concepts can be explored ([LinearTikhonovInversion_App.ipynb](oxa:VNMrkxzChhdveZyf6lmb/8gDAkt6Yn0QN26MssI0p 'LinearTikhonovInversion_App.ipynb')) and all the corresponding figures in this article can be reproduced using [LinearTikhonovInversion_Notebook.ipynb](oxa:VNMrkxzChhdveZyf6lmb/lb7CgEnVPzfs79VcKpB1 'LinearTikhonovInversion_Notebook.ipynb'). The formative material for this chapter is extracted from the tutorial paper Inversion for Applied Geophysics: A Tutorial {cite:p}`Oldenburg20055`.
 
-+++ {"oxa":"oxa:VNMrkxzChhdveZyf6lmb/KV36nNTMujTCmChumcXX.2","tags":[]}
-
 ```{figure} images/VNMrkxzChhdveZyf6lmb-KV36nNTMujTCmChumcXX-v2.png
 :name: KV36nNTMujTCmChumcXX
 :align: center
 :width: 70%
 ```
 
-+++ {"oxa":"oxa:VNMrkxzChhdveZyf6lmb/vQ0IVSS6Mqsyxi19zAKh.2","tags":[]}
-
 **Key Points**
 
 - Forward Problem - model, mesh, kernel function, data, noise
 - Inverse Problem - data misfit, regularization function, norms
 - Optimization - choice of Tikhonov parameter
-
-+++ {"oxa":"oxa:VNMrkxzChhdveZyf6lmb/JvzSg58JHGvfAJap2XD5.3","tags":[]}
 
 ## Contents
 

--- a/content/model-norm.md
+++ b/content/model-norm.md
@@ -15,7 +15,7 @@ Although all of our computations for solving the inverse problem are done using 
 
 +++ {"oxa":"oxa:VNMrkxzChhdveZyf6lmb/s6G5GBmzkACaVMesCwQW.4","tags":[]}
 
-### 2.6.1. Smallest Model Norm
+### Smallest Model Norm
 
 +++ {"oxa":"oxa:VNMrkxzChhdveZyf6lmb/hptZlzW1HfA6qBTD3N54.4","tags":[]}
 
@@ -31,7 +31,7 @@ This norm penalizes the amplitude difference between the sought model $m$ and th
 
 +++ {"oxa":"oxa:VNMrkxzChhdveZyf6lmb/bnA45YXqCAIa26ekWFAJ.2","tags":[]}
 
-### 2.6.2. Flattest Model Norm
+### Flattest Model Norm
 
 +++ {"oxa":"oxa:VNMrkxzChhdveZyf6lmb/V0RZ0YR4ZH7hHSIFgXMR.4","tags":[]}
 
@@ -47,7 +47,7 @@ This norm penalizes derivatives and reduces the amount of structure in the final
 
 +++ {"oxa":"oxa:VNMrkxzChhdveZyf6lmb/gY2E8FqgRyZQipsdTSsF.5","tags":[]}
 
-### 2.6.3. Combined Norms
+### Combined Norms
 
 In most cases we desire a model that is close to a prescribed reference model and is also smooth. Mathematically this can be accomplished by combining the above two norms in a single objective function
 

--- a/content/nonlinear-inversion.md
+++ b/content/nonlinear-inversion.md
@@ -2,29 +2,17 @@
 title: Nonlinear Inversion
 description: ''
 date: '2021-02-10T05:04:54.876Z'
-name: nonlinear-inversion
 venue: nonlinear inversion
-oxa: oxa:VNMrkxzChhdveZyf6lmb/RpEHZD8RmtVqbnbvz2UW
-tags: []
-keywords: []
 thumbnail: thumbnails/nonlinear-inversion.png
 ---
 
-+++ {"oxa":"oxa:VNMrkxzChhdveZyf6lmb/m0onsPFIQcBg7nnKiEtA.2","tags":[]}
-
 In the previous sections we showed how observations from a linear system can be inverted to generate a candidate for the underlying model $m$ that produced the data. The model was found by minimizing an objective function composed of a misfit and regularization function. When both terms were represented as a sum of squares, the objective function is quadratic, and the solution can be found by solving a linear system of equations. In practise, things are often more complicated. This occurs when the mapping in the forward problem, $d=F[m]$, is non-linear, or when a non-quadratic regularization or misfit function is desired. In this case the objective function is non-quadratic and it likely has multiple local minima as well as the desired global minimum. There are many ways to attack this problem and some excellent references are (eg XXXX). In our work we will use iterative techniques where we start at a guessed solution and compute a perturbation step that takes us towards a nearest local minimum.
 
-+++ {"oxa":"oxa:VNMrkxzChhdveZyf6lmb/uBpdWFKxovg4CGTFfaZ2.2","tags":[]}
-
 In this chapter we …..
-
-+++ {"oxa":"oxa:VNMrkxzChhdveZyf6lmb/BzrtD3LpyVTpBCUoFrXv.2","tags":[]}
 
 ## Linear Inversion Review
 
 The inverse problem is set to minimize the objective function $\phi=\phi_d+\beta\phi_m$ with the data misfit function $\phi_d=\sum^N_{j=1}\left(\frac{\mathcal{F}_j(m)-d_j^{obs}}{\varepsilon_j}\right)^2$. For the linear problem, the forward problem is defined as $\mathbf{d}=\mathbf{Gm}$, and we make use of quadratic regularization $\int_v\left(m-m_{ref}\right)^2dv$ so as to solve the problem in one step.
-
-+++ {"oxa":"oxa:VNMrkxzChhdveZyf6lmb/a8DYmKhFpIV654jhtXqZ.2","tags":[]}
 
 ## Non-linear Inversion
 
@@ -34,19 +22,13 @@ The inverse problem becomes non-linear in any of the following cases:
 - when the data misfit $\phi_d$ is not defined using an $l_2$-norm, e.g. $\sum\left|\frac{\mathcal{F}_i[m]-d_i}{\varepsilon_i}\right|$
 - when the model objective function is not quadratic
 
-+++ {"oxa":"oxa:VNMrkxzChhdveZyf6lmb/jinSPCJL0YSc0aEUwmru.2","tags":[]}
-
 ### Forward
 
 The forward problem is defined as $d=\mathcal{F}[m]$. If the forward operation is a linear operator, $\mathbf{d}=\mathbf{Gm}$, but if it is non-linear then $\mathcal{F}[am_1+bm_1] \neq a\mathcal{F}[m_1]+b\mathcal{F}[m_2]$. Such examples of non-linear problems include seismic, Maxwell’s first order wave equation, and DC resistivity.
 
-+++ {"oxa":"oxa:VNMrkxzChhdveZyf6lmb/FMliUY0ER6FB6yT2Od93.2","tags":[]}
-
 ### Inverse Problem
 
 We now solve an optimization problem to minimize the objective function $\phi(m)=\phi_d+\beta\phi_m(m)$. Step 1 is to discretize the PDE and solve the forward problem, then Step 2 is to iterate until a suitable model is found.
-
-+++ {"oxa":"oxa:VNMrkxzChhdveZyf6lmb/GTEyG2CkAR4UcmKjaTk4.3","tags":[]}
 
 ### Non-linear Optimization
 
@@ -78,8 +60,6 @@ where there are now multiple minimums, as shown below.
 :width: 40%
 ```
 
-+++ {"oxa":"oxa:VNMrkxzChhdveZyf6lmb/pesYfX50979COFhTtfHg.3","tags":[]}
-
 #### Newton’s Method
 
 1. Begin with an initial guess of the minimum, $x_k$ along the non-quadratic function we want to minimize, $\mathcal{f}$.
@@ -107,8 +87,6 @@ Things can go wrong with $\delta x=-\frac{\mathcal{f}\prime(x_k)}{\mathcal{f}\pr
 
 If we move in the wrong direction, we likely have negative curvature $\left(-\mathcal{f}\prime\prime(x)\right)$ and should instead use only the gradient $\delta x = c\mathcal{f}\prime (x)$, where $c$ is a constant. We choose $c$ such that $\left|\mathcal{f}(x+\delta x)-\mathcal{f}(x)\right|>\varepsilon$. It is also possible to move in the correct direction, but the curvature $\mathcal{f}\prime\prime(x)$ is wrong, indicating that our step length $\alpha$ is too large. We can change $\alpha$ and scale the step, so the updated guess $x_{k+1}=x_k+\alpha\delta x$ where $\alpha<1$.
 
-+++ {"oxa":"oxa:VNMrkxzChhdveZyf6lmb/wYVzJd0NBUjJqWtlsGUU.2","tags":[]}
-
 #### Convergence Conditions
 
 - $\mathcal{f}\prime(x)<$ tolerance
@@ -120,8 +98,6 @@ If we move in the wrong direction, we likely have negative curvature $\left(-\ma
 :align: center
 :width: 40%
 ```
-
-+++ {"oxa":"oxa:VNMrkxzChhdveZyf6lmb/X0faIneBUQyGfUUbE95M.2","tags":[]}
 
 #### Summary (Newton’s Method)
 
@@ -150,8 +126,6 @@ Non-linear
 - $\delta x=-\frac{\mathcal{f}\prime(x_k)}{\mathcal{f}\prime\prime(x_k)}$
 - $x_{k+1}=x_k+\alpha\delta x, ~ \alpha<1$
 
-+++ {"oxa":"oxa:VNMrkxzChhdveZyf6lmb/9wTkivD1Wp11RoXxA7jc.1","tags":[]}
-
 ### Multivariate functions
 
 - Minimize $\phi(m), ~ m\in\{m_1, m_2, \dots, m_M\}$
@@ -172,15 +146,11 @@ $$\begin{aligned} H(m)&=\nabla_m\nabla^T_m\phi, ~H\in\R^{M\times M} \\ &=\begin{
 
 The minimum of the Hessian is defined such that $H(m^*)$ is positive definite.
 
-+++ {"oxa":"oxa:VNMrkxzChhdveZyf6lmb/Nbx2TafFOTjatznXZvgU.2","tags":[]}
-
 ### Finding a Solution
 
 1. Begin with an initial model $m^{(k)}$
 2. Solve $H\left(m^{(k)}\right)\delta m=-g\left(m^{(k)}\right), ~ \text{c.f.}\{\mathcal{f}\prime\prime(x)\delta x=\mathcal{f}\prime(x)\}$
 3. Update the model $m^{(k+1)}=m^{(k)}+\alpha\delta m$
-
-+++ {"oxa":"oxa:VNMrkxzChhdveZyf6lmb/cSs4mxW0FrRnfT00Hg7v.1","tags":[]}
 
 ### Our Inversion
 
@@ -206,8 +176,6 @@ Final:
 
 $$\begin{aligned} H\delta m &= -g\\ & \downarrow \\ \left(J^TJ+\beta\right)\delta m &=-\left(J^T\delta d+\beta m\right) \\ \delta d &= \mathcal{F}[m]-d^{obs}\end{aligned}$$
 
-+++ {"oxa":"oxa:VNMrkxzChhdveZyf6lmb/AvLVIxig1uLAqXXhMCbN.1","tags":[]}
-
 ### Linear v. Non-linear
 
 Non-linear Problem $\left(\mathcal{F}[m]=d\right)$:
@@ -219,8 +187,6 @@ Linear Problem $(Gm=d)$:
 $$\left(G^TG+\beta\right)\delta m=-\left(G^Td+\beta m\right)$$
 
 The sensitivity $J$ acts as a local linear for non-linear operator $J\delta m=\delta d$
-
-+++ {"oxa":"oxa:VNMrkxzChhdveZyf6lmb/dhcMYZvds7u2UwD3Uojg.1","tags":[]}
 
 ### General Algorithm
 
@@ -239,8 +205,6 @@ There are a variety of ways to solve the system and selecting $\beta$ beyond a l
 :align: center
 :width: 60%
 ```
-
-+++ {"oxa":"oxa:VNMrkxzChhdveZyf6lmb/DLQkbqG42NGTmgIJJN3a.1","tags":[]}
 
 ### Summary
 

--- a/content/nonuniqueness.md
+++ b/content/nonuniqueness.md
@@ -2,22 +2,12 @@
 title: Nonuniqueness
 description: ''
 date: '2021-07-27T18:48:22.184Z'
-name: nonuniqueness
 venue: Linear Tikhonov Inversion
-oxa: oxa:VNMrkxzChhdveZyf6lmb/GnzA9JWkZwIOCRGpfoEU
-tags: []
-keywords: []
 ---
-
-+++ {"oxa":"oxa:VNMrkxzChhdveZyf6lmb/ANgIxKDhtmoGvjQnl6AK.4","tags":[]}
 
 An inversion attempts to solve a linear system of equations where we have fewer equations $(N)$ than we have unknowns $(M)$. In the app the default number of parameters was $100$ while the number of data was $20$. The system of equations is underdetermined and there is an infinite number of models that can fit the data.
 
-+++ {"oxa":"oxa:VNMrkxzChhdveZyf6lmb/nLkIUw91Lwxk7uy50ILv.7","tags":[]}
-
 This nonuniqueness, and insight about how to deal with it, is exemplified by a toy example consisting of two model parameters $\mathbf m = (m_1, m_2)$ and one datum $m_1+2m_2=2$. What is the solution to this problem? In fact any point along the straight line in {numref}`Figure %s <QnSQFBXrMEDwAXuinSO3>` below is a valid solution. Possibilities include $\mathbf m = (1, 0.5)$ or $\mathbf m = (2, 0)$.
-
-+++ {"oxa":"oxa:VNMrkxzChhdveZyf6lmb/QnSQFBXrMEDwAXuinSO3.2","tags":[]}
 
 ```{figure} images/VNMrkxzChhdveZyf6lmb-QnSQFBXrMEDwAXuinSO3-v2.png
 :name: QnSQFBXrMEDwAXuinSO3
@@ -27,11 +17,7 @@ This nonuniqueness, and insight about how to deal with it, is exemplified by a t
 Nonuniqueness
 ```
 
-+++ {"oxa":"oxa:VNMrkxzChhdveZyf6lmb/LjTZihIcM0nejXxwYA18.5","tags":[]}
-
 If our goal is to find a single “best” answer to our inverse problem then we clearly need to incorporate additional information as a constraint. A metaphor that is sometimes helpful is the problem of selecting a specific person in a school classroom as portrayed in the image below {cite:p}`{numref}`Figure %s <8Fvod2SfmrYQX8isU0AC>``. To select a single individual via an optimization framework, we need to define a ruler by which to measure each candidate. A ruler, when applied to any member of the set, generates a single number, and this allows us to find the biggest or smallest member as evaluated with that ruler. The potential rulers are unlimited in number and they could be associated with: height, age, length of fingers, amount of hair, number of wrinkles, etc. In general, choosing a different ruler yields a different solution; although it is possible that the youngest person is also the shortest.
-
-+++ {"oxa":"oxa:VNMrkxzChhdveZyf6lmb/8Fvod2SfmrYQX8isU0AC.2","tags":[]}
 
 ```{figure} images/VNMrkxzChhdveZyf6lmb-8Fvod2SfmrYQX8isU0AC-v2.png
 :name: 8Fvod2SfmrYQX8isU0AC
@@ -41,10 +27,6 @@ If our goal is to find a single “best” answer to our inverse problem then we
 Selecting a specific person in a school classroom.
 ```
 
-+++ {"oxa":"oxa:VNMrkxzChhdveZyf6lmb/38o5NYqVb959O2LcklXN.6","tags":[]}
-
 The analogy with vectors is straight forward. Rulers for measuring length of vectors are quantified via a norm. For instance in the toy example above, the smallest Euclidean length vector that lies along the constraint line is shown by the red dot {cite:p}`{numref}`Figure %s <QnSQFBXrMEDwAXuinSO3>``. Of all of the points it is the one that is closest to the origin, that is, the one for which $(m_1^2 + m_2^2)$ is smallest.
-
-+++ {"oxa":"oxa:VNMrkxzChhdveZyf6lmb/XdTnhWboEv4gm4L5t5NN.1","tags":[]}
 
 A methodology by which we can get a solution to the inverse problem is now clear. We define a “ruler” that can measure the size of each element in our solution space. We choose the one that has the smallest length and that still adequately fits the data. The name for our “ruler” varies but any of the following descriptors are valid: model norm, model objective function, regularization function or regularizer. We’ll use the term “model norm” since we are explicitly concerned the ranking the elements by their “size”.

--- a/content/objective-function-for-the-inverse-problem.md
+++ b/content/objective-function-for-the-inverse-problem.md
@@ -2,18 +2,10 @@
 title: Objective Function for the Inverse Problem
 description: ''
 date: '2021-07-30T20:57:23.168Z'
-name: objective-function-for-the-inverse-problem
 venue: Linear Tikhonov Inversion
-oxa: oxa:VNMrkxzChhdveZyf6lmb/46OlD42gDBzA8SkHBwSK
-tags: []
-keywords: []
 ---
 
-+++ {"oxa":"oxa:VNMrkxzChhdveZyf6lmb/z5DzshyonIYiMpyvruQm.3","tags":[]}
-
 We pose our inverse problem in the following way: find a model $m$ that minimizes the model norm $\phi_m$ and produces an acceptable data misfit $(\phi_d<\phi_d^*)$. To do this we combine the data misfit $\phi_d(m)$ and model norm $\phi_m(m)$ terms and minimize the objective function
-
-+++ {"oxa":"oxa:VNMrkxzChhdveZyf6lmb/QvyNTADmViOIBRurAW2M.6","tags":[]}
 
 ```{math}
 :label: fd471526
@@ -21,15 +13,9 @@ We pose our inverse problem in the following way: find a model $m$ that minimize
 \phi(m) = \phi_d(m)+\beta\phi_m(m)
 ```
 
-+++ {"oxa":"oxa:VNMrkxzChhdveZyf6lmb/ly8rAZgs0J06zFrUvgky.3","tags":[]}
-
 The parameter $\beta$ is known as the Tikhonov parameter or trade-off parameter. It is used to balance the relative influence of the two terms. Note that we explicitly include the dependence of the model $m$ in the two components of the objective function. We do this for clarity, since this is the vector of parameters we want to find. Optimization problems like this are prevalent in society where we want to simultaneously minimize two quantities.
 
-+++ {"oxa":"oxa:VNMrkxzChhdveZyf6lmb/OXTW8i3WCpEtelAzO2ls.1","tags":[]}
-
 As a metaphorical example to understand the role of $\beta$ , we consider the options faced by a traveller who leaves his home at A and wants to drive to location B. He is concerned about travel time T, and fuel consumption F. These quantities are each related to speed. It is not possible to simultaneously minimize both T and F so the compromise is to consider
-
-+++ {"oxa":"oxa:VNMrkxzChhdveZyf6lmb/bZ96k0YcsCv0EP1eoqhM.4","tags":[]}
 
 ```{math}
 :label: 7c304ef3
@@ -37,11 +23,7 @@ As a metaphorical example to understand the role of $\beta$ , we consider the op
 \phi=T+\beta F
 ```
 
-+++ {"oxa":"oxa:VNMrkxzChhdveZyf6lmb/ag79PFLKWAt6nrpamhsq.6","tags":[]}
-
 When $\beta → 0$ we minimize the time irrespective of the fuel consumption. The gas peddle is on the floor. When $\beta → \infin$ the driver wants to use the absolute minimum amount of fuel so the gas peddle is barely engaged. This is displayed in {numref}`Figure %s <d31AdH08dO30KTmaxlYO>` where both T and F are plotted as a function of $\beta$. It is customary have the $\beta$ axis extend from a high value $\beta_H$ to a low value $\beta_L$ and this is indicated in the first two plots. A plot of $T~\text{vs}~F$ is shown in the third plot of {numref}`Figure %s <d31AdH08dO30KTmaxlYO>`. This is a monotonic curve and each point on the curve corresponds to a single $\beta$.
-
-+++ {"oxa":"oxa:VNMrkxzChhdveZyf6lmb/d31AdH08dO30KTmaxlYO.2","tags":[]}
 
 ```{figure} images/VNMrkxzChhdveZyf6lmb-d31AdH08dO30KTmaxlYO-v2.png
 :name: d31AdH08dO30KTmaxlYO
@@ -49,15 +31,9 @@ When $\beta → 0$ we minimize the time irrespective of the fuel consumption. Th
 :width: 70%
 ```
 
-+++ {"oxa":"oxa:VNMrkxzChhdveZyf6lmb/OBBaiqDj1UbmyP1vNT35.8","tags":[]}
-
 The tradeoff curve, often referred to as the Tikhonov curve, provides a suite of possible outcomes. A specific outcome may be obtained after applying an additional constraint: Suppose we want to minimize $F$, subject to a desired travel time $T^*=2hr$. That target value is plotted on the third diagram in {numref}`Figure %s <d31AdH08dO30KTmaxlYO>`.
 
-+++ {"oxa":"oxa:VNMrkxzChhdveZyf6lmb/06wVl7O0rPQVMNFxLla8.3","tags":[]}
-
 The relationship between the travel example and the objective function for the inversion problem (Equation 2.17) is clear when the Tikhonov curve in {numref}`Figure %s <d31AdH08dO30KTmaxlYO>` is compared to that in {numref}`Figure %s <E9qugPIRBWvRhBsBAThm>`. The travel time $T$ is analogous to the data misfit $\phi_d$ and the target $T^*$ is analogous to the target misfit $\phi_d^*$ . The fuel consumption $F$ is analogous to the model norm $\phi_m$.
-
-+++ {"oxa":"oxa:VNMrkxzChhdveZyf6lmb/E9qugPIRBWvRhBsBAThm.2","tags":[]}
 
 ```{figure} images/VNMrkxzChhdveZyf6lmb-E9qugPIRBWvRhBsBAThm-v2.png
 :name: E9qugPIRBWvRhBsBAThm
@@ -65,29 +41,17 @@ The relationship between the travel example and the objective function for the i
 :width: 70%
 ```
 
-+++ {"oxa":"oxa:VNMrkxzChhdveZyf6lmb/Br1UjFWty7rYiqlb3Wm6.4","tags":[]}
-
 We have now generated the important components for our inverse problem. The misfit and model norm have been defined and minimization of our combined objective function {eq}`fd471526` yields a specific model to be interpreted. An important remaining item is “what value of $\beta$ is appropriate”?
 
-+++ {"oxa":"oxa:VNMrkxzChhdveZyf6lmb/ZM5nw7EUDUm1PyEmMPGx.3","tags":[]}
-
 A priori, we have no way of estimating an optimal $\beta^*$ and in practice it can vary by many orders of magnitude in different problems. To address this, we choose a suite of $\beta$ values that extend over many orders of magnitude, and then minimize {eq}`fd471526` for each $\beta_k$. Each minimization provides a model $m_k$, a misfit $\phi_{dk}$ and a model norm $\phi_{mk}$. These values can be plotted as shown below in the inversion simulation using the model and data created above ([Figure E](https://curvenote.com/oxa:VNMrkxzChhdveZyf6lmb/ejAaQ7Q2KvAmHkRE6dwa.18)). One choice for an optimal trade-off parameter $\beta^*$ is based upon the target misfit $\phi_d^*$. In practice however, we shall want to examine the Tikhonov curve more closely and use characteristics of that to help make a decision.
-
-+++ {"oxa":"oxa:VNMrkxzChhdveZyf6lmb/ejAaQ7Q2KvAmHkRE6dwa.18","tags":[]}
 
 ```{mdast} objective-function-for-the-inverse-problem.mdast.json#CUhrplldNs
 
 ```
 
-+++ {"oxa":"oxa:VNMrkxzChhdveZyf6lmb/WTMLL1nxDUXjSsyYlgco.3","tags":[]}
-
 **Figure E:** Inversion simulation results using the model ([2.3. Forward Problem](oxa:VNMrkxzChhdveZyf6lmb/xqM34l8moONMZ4iDWIQf '2.3. Forward Problem')-[Figure A](https://curvenote.com/oxa:VNMrkxzChhdveZyf6lmb/8WfrIYP5O9W6zakEQaa3.7)) and data ([2.3. Forward Problem](oxa:VNMrkxzChhdveZyf6lmb/xqM34l8moONMZ4iDWIQf '2.3. Forward Problem')-[Figure D](https://curvenote.com/oxa:VNMrkxzChhdveZyf6lmb/f4ZOfRjwPn87rmRQmgT3.9)) created in the Forward process above. The first panel displays the true model and recovered model from the inversion. The second panel shows both the observed (noisy) data and predicted data from the inversion. The third panel displays the data misfit and model norm terms as function of the trade-off parameter $\beta$, having run a suit of inversions with different values $\beta_k$, the optimal $\beta^*$ value indicated by the star. [LinearTikhonovInversion_Notebook.ipynb](oxa:VNMrkxzChhdveZyf6lmb/lb7CgEnVPzfs79VcKpB1 'LinearTikhonovInversion_Notebook.ipynb')
 
-+++ {"oxa":"oxa:VNMrkxzChhdveZyf6lmb/NHw33lGPn7Z9fmRjPGrH.2","tags":[]}
-
 If $\beta$ is too large, the model $\mathbf{m}$ is underfitting the data, causing loss of structural information.
-
-+++ {"oxa":"oxa:VNMrkxzChhdveZyf6lmb/ZJvsuAh5doPl7d9VBAON.4","tags":[]}
 
 ```{figure} images/VNMrkxzChhdveZyf6lmb-ZJvsuAh5doPl7d9VBAON-v4.png
 :name: ZJvsuAh5doPl7d9VBAON
@@ -95,19 +59,13 @@ If $\beta$ is too large, the model $\mathbf{m}$ is underfitting the data, causin
 :width: 70%
 ```
 
-+++ {"oxa":"oxa:VNMrkxzChhdveZyf6lmb/LxF0fImli3FufWtnmAV5.2","tags":[]}
-
 ```{figure} images/VNMrkxzChhdveZyf6lmb-LxF0fImli3FufWtnmAV5-v2.png
 :name: LxF0fImli3FufWtnmAV5
 :align: center
 :width: 70%
 ```
 
-+++ {"oxa":"oxa:VNMrkxzChhdveZyf6lmb/NPLpHWxCnHPSnqTZHfTm.2","tags":[]}
-
 If $\beta$ is too small, the model $\mathbf{m}$ is overfitting the data, causing noise to be imaged as structure.
-
-+++ {"oxa":"oxa:VNMrkxzChhdveZyf6lmb/HjWa8hCAUYbiYNyQqLh6.3","tags":[]}
 
 ```{figure} images/VNMrkxzChhdveZyf6lmb-HjWa8hCAUYbiYNyQqLh6-v3.png
 :name: HjWa8hCAUYbiYNyQqLh6
@@ -115,14 +73,10 @@ If $\beta$ is too small, the model $\mathbf{m}$ is overfitting the data, causing
 :width: 70%
 ```
 
-+++ {"oxa":"oxa:VNMrkxzChhdveZyf6lmb/Hx4fVnPbS2LUU4eiZOLF.2","tags":[]}
-
 ```{figure} images/VNMrkxzChhdveZyf6lmb-Hx4fVnPbS2LUU4eiZOLF-v2.png
 :name: Hx4fVnPbS2LUU4eiZOLF
 :align: center
 :width: 70%
 ```
-
-+++ {"oxa":"oxa:VNMrkxzChhdveZyf6lmb/kdrgidlY4lhnipbg5z1q.3","tags":[]}
 
 If $\beta$ is just right $(\phi^*_d \simeq N)$, the model $\mathbf{m}$ optimally fits the data, producing the best estimate to adequately recreate the observations as was shown in [Figure E](https://curvenote.com/oxa:VNMrkxzChhdveZyf6lmb/ejAaQ7Q2KvAmHkRE6dwa.18).

--- a/content/solving-an-ill-posed-problem.md
+++ b/content/solving-an-ill-posed-problem.md
@@ -2,28 +2,18 @@
 title: Solving an Ill-Posed Problem
 description: ''
 date: '2021-07-27T01:35:08.455Z'
-name: solving-an-ill-posed-problem
 venue: Inverse Theory
-oxa: oxa:VNMrkxzChhdveZyf6lmb/qBQLb0mjfX4F2rlYGCDV
-tags: []
-keywords: []
 ---
-
-+++ {"oxa":"oxa:VNMrkxzChhdveZyf6lmb/XZKD3MLz4GD4ALcDrrnz.3","tags":[]}
 
 The above work shows that the inverse problem is nonunique and ill-conditioned. This leads to the statement that “the inverse problem is ill-posed”. Any framework must handle these fundamental elements.
 
 The major weapon for handling nonuniqueness is to add more information and find a model that satisfies the geophysical data as well as this a priori information. The simplified flow chart for the inversion is now shown in {numref}`Figure %s <GeAbXOZ9BeAMekQ4U0UN>`.
-
-+++ {"oxa":"oxa:VNMrkxzChhdveZyf6lmb/GeAbXOZ9BeAMekQ4U0UN.2","tags":[]}
 
 ```{figure} images/VNMrkxzChhdveZyf6lmb-GeAbXOZ9BeAMekQ4U0UN-v2.png
 :name: GeAbXOZ9BeAMekQ4U0UN
 :align: center
 :width: 40%
 ```
-
-+++ {"oxa":"oxa:VNMrkxzChhdveZyf6lmb/uG8rpHszmoS06i7AUy4B.1","tags":[]}
 
 The prior information takes many forms and throughout this module we will have opportunity to illustrate all of them. When thinking about a general geophysical inversion where we attempt to find a distribution of a physical property that can be translated into geology, we might have:
 
@@ -36,25 +26,17 @@ The prior information takes many forms and throughout this module we will have o
 
 The second issue of importance is the ill-conditioning of the inverse problem. The fundamental ill-conditioning is often automatically ameliorated by adding additional information into the problem. For instance, when adding a smallest model component into a Tikhonov inversion. However, there will always be ill-conditioning resulting from over-fitting noisy data and this needs to be addressed.
 
-+++ {"oxa":"oxa:VNMrkxzChhdveZyf6lmb/baO1UGq3eBSEdOz88AnV.5","tags":[]}
-
 There are two general approaches to solving the inverse problem. The first is a probabilistic approach that rests on Bayesian analysis.
 
-+++ {"oxa":"oxa:VNMrkxzChhdveZyf6lmb/bWlsHXqqVcUjWfu2bC6A.3","tags":[]}
-
-### 1.6.1. Bayesian (Probabilistic)
+### Bayesian (Probabilistic)
 
 Use Bayes’ Theorem
-
-+++ {"oxa":"oxa:VNMrkxzChhdveZyf6lmb/R13nNIFBXYUFWWW3iuEr.7","tags":[]}
 
 ```{math}
 :label: d44e43b7
 
 P(m|d^{obs})\propto P(d^{obs}|m)P(m)
 ```
-
-+++ {"oxa":"oxa:VNMrkxzChhdveZyf6lmb/y3HxBjDbjGSo8VsOi6JO.2","tags":[]}
 
 where $P(m)$ is the prior information about $m$, $P(d^{obs}|m)$ is the probability about the data errors (likelihood), and $P(m|d^{obs})$ is the posterior probability for the model.
 
@@ -63,20 +45,14 @@ $P(m|d^{obs})$ and draw inferences from that distribution. The second is to find
 
 Abundant resources for inversion using a Bayesian philosophy exist, but a classic is that of {cite:t}`tarantola_inverse_2005`. We will have occasion towards the latter part of this module to work with a Bayesian formulation but most of our work will use the Tikhonov method.
 
-+++ {"oxa":"oxa:VNMrkxzChhdveZyf6lmb/n2TLIO1qnaFdZacg3vTt.4","tags":[]}
-
-### 1.6.2. Tikhonov (Deterministic)
+### Tikhonov (Deterministic)
 
 In this approach the goal is to find a single “best” solution by solving an optimization problem:
-
-+++ {"oxa":"oxa:VNMrkxzChhdveZyf6lmb/df5PAaspJSNpPmBJ7nwu.7","tags":[]}
 
 ```{math}
 :label: 7633cf80
 
 \begin{aligned}&\text{Minimize}~~\phi=\phi_d+\beta\phi_m\\ &\text{subject to}~~m_l<m<m_u,\end{aligned}
 ```
-
-+++ {"oxa":"oxa:VNMrkxzChhdveZyf6lmb/tCT8qNmysGlpwIDYsfF9.2","tags":[]}
 
 where $\phi_d$ is the data misfit, $\phi_m$ is the regularization (model norm), $\beta$ is the trade-off parameter, and $m_l, m_u$ are lower and upper bounds on the model. The constraints on the model from the geophysical information are embedded in the data misfit while the a priori information is encoded into the model norm and bounds.

--- a/content/statement-of-the-inverse-problem.md
+++ b/content/statement-of-the-inverse-problem.md
@@ -2,18 +2,10 @@
 title: Defining the Inverse Problem
 description: ''
 date: '2021-07-27T18:04:01.725Z'
-name: statement-of-the-inverse-problem
 venue: Linear Tikhonov Inversion
-oxa: oxa:VNMrkxzChhdveZyf6lmb/iPh2GcyPHcbKFJrzGLc4
-tags: []
-keywords: []
 ---
 
-+++ {"oxa":"oxa:VNMrkxzChhdveZyf6lmb/dGelkLiTk1csJHaM8AU8.3","tags":[]}
-
 In a typical physical problem we perform an experiment to collect data and use those data to infer something about the earth. The procedure is schematically represented in the diagram below. The “inversion processing” is the computational component that links the observations to the unknown earth model.
-
-+++ {"oxa":"oxa:VNMrkxzChhdveZyf6lmb/cFtpNM4K3qAT83AO13wl.3","tags":[]}
 
 ```{figure} images/VNMrkxzChhdveZyf6lmb-cFtpNM4K3qAT83AO13wl-v3.png
 :name: cFtpNM4K3qAT83AO13wl
@@ -21,11 +13,7 @@ In a typical physical problem we perform an experiment to collect data and use t
 :width: 70%
 ```
 
-+++ {"oxa":"oxa:VNMrkxzChhdveZyf6lmb/zJDOeckTE5abcJopQU2h.13","tags":[]}
-
 Let $m$ be a generic symbol for the physical property or parameters that are being sought. We refer to $m$ as the “model”. A more rigorous statement of the inverse problem is: “Given observed data, $d_{j}^{obs}$, where $j=1,\dots,N$, an estimate of their uncertainties, $\epsilon_j$, and the ability to carry out forward modelling,
-
-+++ {"oxa":"oxa:VNMrkxzChhdveZyf6lmb/58SCTuc4u4OkpuZPuoUB.5","tags":[]}
 
 ```{math}
 :label: 3ffde9a8
@@ -33,8 +21,6 @@ Let $m$ be a generic symbol for the physical property or parameters that are bei
 d_j=\mathcal{F}_j[m]
 ```
 
-+++ {"oxa":"oxa:VNMrkxzChhdveZyf6lmb/3EPmPnjyjaHxreLlKGXY.5","tags":[]}
-
-find the model that generated the data”. The quantity $\mathcal{F_j}$ is the forward modelling operator that was explained in [1. Inverse Theory Overview](oxa:VNMrkxzChhdveZyf6lmb/n4krShPqra002w55QQvU '1. Inverse Theory Overview'). It encompasses the physical equations, geometries and all details about the source and receiver.
+find the model that generated the data”. The quantity $\mathcal{F_j}$ is the forward modelling operator that was explained in [Inverse Theory Overview](./inverse-theory-overview.md). It encompasses the physical equations, geometries and all details about the source and receiver.
 
 Solving an inverse problem using optimization theory is a multi-step process and in this section we look at each component in detail. It suffices to work with a simple synthetic example to establish fundamental principles that will be essential for every inverse problem we encounter. We first develop the forward modelling.

--- a/content/summary-linear-inversion.md
+++ b/content/summary-linear-inversion.md
@@ -2,9 +2,5 @@
 title: Summary
 description: ''
 date: '2021-07-27T21:44:24.839Z'
-name: summary-linear-inversion
 venue: Linear Tikhonov Inversion
-oxa: oxa:VNMrkxzChhdveZyf6lmb/yzHCnqTZhhwEGB1CTUa9
-tags: []
-keywords: []
 ---

--- a/content/theory-summary.md
+++ b/content/theory-summary.md
@@ -2,13 +2,7 @@
 title: Summary
 description: ''
 date: '2021-07-27T01:34:58.306Z'
-name: theory-summary
 venue: Inverse Theory
-oxa: oxa:VNMrkxzChhdveZyf6lmb/0UQMQyTBjdb0AmPdjELK
-tags: []
-keywords: []
 ---
-
-+++ {"oxa":"oxa:VNMrkxzChhdveZyf6lmb/ajKg8LD9Aq167LYvbQkn.5","tags":[]}
 
 In this chapter we have defined important elements that will be used throughout this inversion module. These include forward and inverse mappings, their associated vector spaces and the difference between linear and nonlinear problems. The fundamental statement that “the inverse problem is ill-posed” is illustrated by considering the relationship between the interval and rms velocities in reflection seismology. A Jupyter notebook allows readers to verify the statements made in the text and to carry out further exploration regarding the nonuniqueness and ill-conditioning that is inherent in the inverse problem. Any inversion formalism must address these two aspects and identify two major pathways by which this can be done. The first uses a Bayesian framework based in probability theory. The second, is a deterministic approach where an optimization problem is solved to provide a specific solution for the inverse problem. This is a Tikhonov approach and we explore this in the [next chapter](https://curvenote.com/@geosci/inversion-module/linear-tikhonov-inversion).

--- a/myst.yml
+++ b/myst.yml
@@ -4,37 +4,31 @@ project:
   description: ''
   remote: VNMrkxzChhdveZyf6lmb
   authors:
-    - userId: kJ1wjvSFymWWBKGfgdlwXFWwwkw2
-      nameParsed:
-        literal: Douglas Oldenburg
-        given: Douglas
-        family: Oldenburg
-      name: Douglas Oldenburg
-      corresponding: false
+    - name: Douglas Oldenburg
       roles:
         - Conceptualization
       affiliations:
         - University of British Columbia
-      id: contributors-generated-uid-0
-    - userId: uGKcpSd8C8Ngzg9FusKDcQp0kIb2
-      nameParsed:
-        literal: Lindsey Heagy
-        given: Lindsey
-        family: Heagy
-      name: Lindsey Heagy
+    - name: Lindsey Heagy
       orcid: 0000-0002-1551-5926
-      corresponding: false
       roles:
         - Writing – original draft
       affiliations:
         - University of British Columbia
-      id: contributors-generated-uid-1
   name: inversion-module
   open_access: true
   license:
     content: CC-BY-4.0
     code: MIT
   subject: Inversion Module
+  numbering:
+    headings: true
+  abbreviations:
+    UXO: Unexploded ordnance
+    Rx: receivers
+    Tx: Transmitters
+    DC: Direct Current
+    EM: Electromagnetic(s)
 site:
   title: Inversion module
   description: ''
@@ -44,4 +38,4 @@ site:
       url: https://curvenote.com/docs/web
   domains: []
   logo: public/logo.svg
-  logoText: Inversion module
+  logo_text: Inversion module


### PR DESCRIPTION
This is starting to go through and do some clean ups.

I did change a few things and add some very minor figure captions. Starting to take advantage of some myst things:

![image](https://github.com/geoscixyz/inversion/assets/913249/7424040d-a834-4ada-99cf-38e7d7898c11)

I think going through and renaming images back to sensible things will be helpful.

I was also wondering if - as this book is already pretty big, if we could name the chapters `01_01_geophysical_experiments.md` or something?