### PR TITLE
linear forward example 

### DIFF
--- a/content/forward-mapping.md
+++ b/content/forward-mapping.md
@@ -61,7 +61,7 @@ Let $f$ and $g$ be two elements of the model space and $\alpha$ and $\beta$ be t
 
 $$
 \label{eq:linear-mapping}
-\mathcal{F}[\alpha f+\beta g]=\alpha\mathcal{F}[f]+\beta\mathcal{F}[g]
+\mathcal{F}[\alpha m_1+\beta m_2]=\alpha\mathcal{F}[m_1]+\beta\mathcal{F}[m_2]
 $$
 
 When this does not hold, the mapping is said to be nonlinear.


### PR DESCRIPTION
Update the notation in the forward mapping to use m1, m2 rather than f, g (which are easily confused with kernels)

$\mathcal{F}[\alpha f + \beta g]$ --> $\mathcal{F}[\alpha m_1 + \beta m_2]$

In the page: https://geoscixyz.github.io/inversion/forward-mapping#linear-and-nonlinear-mappings